### PR TITLE
위시 아이템 디테일 화면 UI 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/BottomBarNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/BottomBarNavHost.kt
@@ -6,13 +6,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.hyeeyoung.wishboard.config.navigation.screen.Main
-import com.hyeeyoung.wishboard.presentation.home.HomeScreen
+import com.hyeeyoung.wishboard.presentation.wish.WishlistScreen
 
 @Composable
 fun BottomBarNavHost(modifier: Modifier = Modifier, navController: NavHostController) {
-    NavHost(modifier = modifier, navController = navController, startDestination = Main.Home.route) {
-        composable(route = Main.Home.route) {
-            HomeScreen()
+    NavHost(modifier = modifier, navController = navController, startDestination = Main.Wishlist.route) {
+        composable(route = Main.Wishlist.route) {
+            WishlistScreen()
         }
         composable(route = Main.Folder.route) {
             /** TODO */

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
@@ -2,7 +2,7 @@ package com.hyeeyoung.wishboard.config.navigation.screen
 
 sealed class Main(override val route: String) : Screen {
     object Root : Main(route = "mainRoot")
-    object Home : Main(route = "home")
+    object Wishlist : Main(route = "wishlist")
     object Folder : Main(route = "folder")
     object Add : Main(route = "add")
     object Noti : Main(route = "noti")

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/bottombar/WishBoardBottomBar.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/bottombar/WishBoardBottomBar.kt
@@ -91,7 +91,7 @@ enum class BottomNavItem(
     @DrawableRes val icon: Int,
     val screen: Screen,
 ) {
-    WishList(R.string.nav_menu_label_wishlist, R.drawable.ic_nav_wish_list, Main.Home),
+    WishList(R.string.nav_menu_label_wishlist, R.drawable.ic_nav_wish_list, Main.Wishlist),
     Folder(R.string.nav_menu_label_folder, R.drawable.ic_nav_folder, Main.Folder),
     Add(R.string.nav_menu_label_add, R.drawable.ic_nav_write, Main.Add),
     Notice(R.string.nav_menu_label_notice, R.drawable.ic_nav_notice, Main.Noti),

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/button/WishBoardWideButton.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/button/WishBoardWideButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -15,19 +16,37 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 
 @Composable
-fun WishBoardWideButton(modifier: Modifier = Modifier, enabled: Boolean, onClick: () -> Unit, text: String) {
-    Button(
-        modifier = modifier
-            .fillMaxWidth(),
-        onClick = { onClick() },
-        shape = RoundedCornerShape(24.dp),
-        enabled = enabled,
-        colors = ButtonDefaults.buttonColors(
+fun WishBoardWideButton(
+    modifier: Modifier = Modifier,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    text: String,
+    shape: Shape = RoundedCornerShape(24.dp),
+    isGreen: Boolean = true,
+) {
+    val color = if (isGreen) {
+        ButtonDefaults.buttonColors(
             containerColor = WishBoardTheme.colors.green500,
             disabledContainerColor = WishBoardTheme.colors.gray100,
             contentColor = WishBoardTheme.colors.gray700,
             disabledContentColor = WishBoardTheme.colors.gray300,
-        ),
+        )
+    } else {
+        ButtonDefaults.buttonColors(
+            containerColor = WishBoardTheme.colors.gray700,
+            disabledContainerColor = WishBoardTheme.colors.gray100,
+            contentColor = WishBoardTheme.colors.white,
+            disabledContentColor = WishBoardTheme.colors.gray300,
+        )
+    }
+
+    Button(
+        modifier = modifier
+            .fillMaxWidth(),
+        onClick = { onClick() },
+        shape = shape,
+        enabled = enabled,
+        colors = color,
         contentPadding = PaddingValues(vertical = 15.dp),
     ) {
         Text(

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/topbar/WishBoardTopBar.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/topbar/WishBoardTopBar.kt
@@ -74,3 +74,21 @@ fun WishBoardTopBar(topBarModel: WishBoardTopBarModel, endComponent: (@Composabl
 fun PreviewWishBoardTopBar() {
     WishBoardTopBar(topBarModel = WishBoardTopBarModel(title = stringResource(id = R.string.sign_in_title)))
 }
+
+@Preview
+@Composable
+fun PreviewWishBoardTopBarWithEndIcons() {
+    WishBoardTopBar(
+        topBarModel = WishBoardTopBarModel(),
+        endComponent = { modifier ->
+            Row(
+                modifier = modifier,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                WishBoardIconButton(iconRes = R.drawable.ic_trash, onClick = { /*TODO*/ })
+                WishBoardIconButton(iconRes = R.drawable.ic_edit, onClick = { /*TODO*/ })
+                Spacer(modifier = Modifier.size(8.dp))
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/style/Type.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/style/Type.kt
@@ -126,6 +126,7 @@ data class WishBoardTypography(
         fontWeight = FontWeight.Normal,
         fontSize = 9.sp,
     ),
+    val suitB1M: TextStyle = suitB1.copy(lineHeight = 22.sp),
     val suitB3M: TextStyle = suitB3.copy(lineHeight = 20.sp),
     val suitD2M: TextStyle = suitD2.copy(lineHeight = 20.sp),
 )

--- a/app/src/main/java/com/hyeeyoung/wishboard/domain/model/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/domain/model/WishItem.kt
@@ -1,6 +1,6 @@
 package com.hyeeyoung.wishboard.domain.model
 
-data class WishItem(
+data class WishItem( // TODO presentation > model 패키지로 이동
     val id: Long,
     val name: String,
     val imageUrl: String,

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/model/WishItemDetail.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/model/WishItemDetail.kt
@@ -1,0 +1,18 @@
+package com.hyeeyoung.wishboard.presentation.model
+
+import com.hyeeyoung.wishboard.presentation.util.type.NotiType
+import java.time.LocalDateTime
+
+data class WishItemDetail(
+    val id: Long,
+    val name: String,
+    var image: String? = null,
+    val price: Int,
+    val notiDate: LocalDateTime? = null,
+    val notiType: NotiType? = null,
+    val site: String? = null,
+    val memo: String? = null,
+    var folderId: Long? = null,
+    var folderName: String? = null,
+    val createAt: String,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/SafeLet.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/SafeLet.kt
@@ -1,0 +1,14 @@
+package com.hyeeyoung.wishboard.presentation.util
+
+inline fun <T1 : Any, T2 : Any, R : Any> safeLet(p1: T1?, p2: T2?, block: (T1, T2) -> R?): R? {
+    return if (p1 != null && p2 != null) block(p1, p2) else null
+}
+
+inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> safeLet(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    block: (T1, T2, T3) -> R?,
+): R? {
+    return if (p1 != null && p2 != null && p3 != null) block(p1, p2, p3) else null
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/type/NotiType.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/type/NotiType.kt
@@ -1,0 +1,10 @@
+package com.hyeeyoung.wishboard.presentation.util.type
+
+enum class NotiType(val str: String) {
+    RESTOCK("재입고"),
+    OPEN("오픈"),
+    PREORDER("프리오더"),
+    SALE_START("세일 시작"),
+    SALE_CLOSE("세일 마감"),
+    REMIND("리마인드"),
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
@@ -3,41 +3,27 @@ package com.hyeeyoung.wishboard.presentation.wish
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hyeeyoung.wishboard.R
-import com.hyeeyoung.wishboard.designsystem.component.button.CartButton
-import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 import com.hyeeyoung.wishboard.domain.model.WishItem
-import com.hyeeyoung.wishboard.presentation.util.extension.setPriceFormat
+import com.hyeeyoung.wishboard.presentation.wish.component.WishItem
 
 @Composable
 fun WishlistScreen(modifier: Modifier = Modifier) {
@@ -96,7 +82,7 @@ fun WishlistScreen(modifier: Modifier = Modifier) {
                         ),
                     columns = GridCells.Fixed(2),
                 ) {
-                    items(wishList) { wishItem -> WishItemComponent(wishItem = wishItem) }
+                    items(wishList) { wishItem -> WishItem(wishItem = wishItem) }
                 }
             }
         }
@@ -120,55 +106,6 @@ fun WishlistTopBar() { // TODO 공용 TopBar 추출
         Row() {
             WishBoardIconButton(iconRes = R.drawable.ic_cart, onClick = {})
             WishBoardIconButton(iconRes = R.drawable.ic_calendar, onClick = {})
-        }
-    }
-}
-
-@Composable
-fun WishItemComponent(wishItem: WishItem) {
-    Column {
-        var cartState by remember { mutableStateOf(wishItem.isInCart) }
-        // 이미지 및 장바구니 버튼
-        Box {
-            ColoredImage(
-                model = wishItem.imageUrl,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .aspectRatio(1f),
-            )
-
-            Column(
-                modifier = Modifier
-                    .padding(10.dp)
-                    .align(Alignment.BottomEnd),
-            ) {
-                CartButton(
-                    isInCart = cartState,
-                    changeCartState = { isInCart -> cartState = !isInCart },
-                )
-            }
-        }
-
-        // 상품명 및 가격
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 10.dp, end = 10.dp, top = 10.dp, bottom = 20.dp),
-        ) {
-            Text(text = wishItem.name, style = WishBoardTheme.typography.suitD3, color = WishBoardTheme.colors.gray700)
-            Spacer(modifier = Modifier.size(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = wishItem.price.setPriceFormat(),
-                    style = WishBoardTheme.typography.montserratH3,
-                    color = WishBoardTheme.colors.gray700,
-                )
-                Text(
-                    text = stringResource(id = R.string.won),
-                    style = WishBoardTheme.typography.suitD3,
-                    color = WishBoardTheme.colors.gray700,
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
@@ -1,4 +1,4 @@
-package com.hyeeyoung.wishboard.presentation.home
+package com.hyeeyoung.wishboard.presentation.wish
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -40,7 +40,7 @@ import com.hyeeyoung.wishboard.domain.model.WishItem
 import com.hyeeyoung.wishboard.presentation.util.extension.setPriceFormat
 
 @Composable
-fun HomeScreen(modifier: Modifier = Modifier) {
+fun WishlistScreen(modifier: Modifier = Modifier) {
     val wishList = listOf(
         WishItem(
             1L,
@@ -87,7 +87,7 @@ fun HomeScreen(modifier: Modifier = Modifier) {
     )
     WishboardTheme { // TODO Theme 사용 여부 고려
         Surface(modifier = modifier) {
-            Scaffold(topBar = { HomeTopBar() }) { paddingValues ->
+            Scaffold(topBar = { WishlistTopBar() }) { paddingValues ->
                 LazyVerticalGrid(
                     modifier = Modifier
                         .background(WishBoardTheme.colors.white)
@@ -104,7 +104,7 @@ fun HomeScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun HomeTopBar() {
+fun WishlistTopBar() { // TODO 공용 TopBar 추출
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -175,6 +175,6 @@ fun WishItemComponent(wishItem: WishItem) {
 
 @Composable
 @Preview
-fun PreviewHomeScreen() {
-    HomeScreen(Modifier)
+fun PreviewWishlistScreen() {
+    WishlistScreen(Modifier)
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
@@ -1,0 +1,228 @@
+package com.hyeeyoung.wishboard.presentation.wish
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
+import com.hyeeyoung.wishboard.designsystem.util.buildStringWithSpans
+import com.hyeeyoung.wishboard.presentation.model.WishBoardString
+import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
+import com.hyeeyoung.wishboard.presentation.model.WishItemDetail
+import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
+import com.hyeeyoung.wishboard.presentation.util.safeLet
+import com.hyeeyoung.wishboard.presentation.util.type.NotiType
+import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
+import java.time.LocalDateTime
+
+@Composable
+fun WishItemDetailScreen(itemDetail: WishItemDetail) {
+    WishboardTheme { // TODO Theme 사용 여부 고려
+        Scaffold(topBar = {
+            WishBoardTopBar(
+                WishBoardTopBarModel(onClickStartIcon = { /*TODO*/ }),
+                endComponent = { modifier -> TopBarEndIcons(modifier) },
+            )
+        }) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .padding(top = paddingValues.calculateTopPadding()),
+            ) {
+                WishItemDetailContents(modifier = Modifier.weight(1f), itemDetail = itemDetail)
+
+                WishBoardWideButton(
+                    enabled = itemDetail.site != null,
+                    onClick = { /*TODO*/ },
+                    text = stringResource(id = R.string.wish_item_detail_go_to_shop),
+                    shape = RectangleShape,
+                    isGreen = false,
+                ) // TODO 비활성화 처리
+            }
+        }
+    }
+}
+
+@Composable
+private fun WishItemDetailContents(modifier: Modifier, itemDetail: WishItemDetail) {
+    Column(modifier = modifier.verticalScroll(rememberScrollState())) {
+        Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp)) {
+            ColoredImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(32.dp))
+                    .aspectRatio(1f / 1.15f),
+                model = itemDetail.image,
+            )
+
+            safeLet(itemDetail.notiType, itemDetail.notiDate) { type, date ->
+                NotiInfoLabel(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(16.dp),
+                    type = type,
+                    date = date,
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FolderGuideString()
+            Text(
+                text = itemDetail.createAt,
+                style = WishBoardTheme.typography.suitD3,
+                color = WishBoardTheme.colors.gray300,
+            )
+        }
+
+        Column(Modifier.padding(start = 16.dp, end = 16.dp, top = 10.dp, bottom = 20.dp)) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = itemDetail.name,
+                style = WishBoardTheme.typography.suitB1M,
+                color = WishBoardTheme.colors.gray700,
+            )
+
+            PriceText(
+                modifier = Modifier.padding(top = 20.dp),
+                price = itemDetail.price,
+                priceStyle = WishBoardTheme.typography.montserratH2,
+                wonStyle = WishBoardTheme.typography.suitD2,
+            )
+        }
+
+        itemDetail.site?.let { site ->
+            WishBoardDivider()
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = site,
+                style = WishBoardTheme.typography.suitD3,
+                color = WishBoardTheme.colors.gray300,
+            )
+        }
+
+        itemDetail.memo?.let { memo ->
+            WishBoardDivider()
+            Column(Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 64.dp)) {
+                Text(
+                    modifier = Modifier.padding(bottom = 10.dp),
+                    text = stringResource(id = R.string.memo),
+                    style = WishBoardTheme.typography.suitB2,
+                    color = WishBoardTheme.colors.gray700,
+                )
+                Text(
+                    text = memo,
+                    style = WishBoardTheme.typography.suitD2,
+                    color = WishBoardTheme.colors.gray700,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TopBarEndIcons(modifier: Modifier) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        WishBoardIconButton(iconRes = R.drawable.ic_trash, onClick = { /*TODO*/ })
+        WishBoardIconButton(iconRes = R.drawable.ic_edit, onClick = { /*TODO*/ })
+        Spacer(modifier = Modifier.size(8.dp))
+    }
+}
+
+@Composable
+private fun NotiInfoLabel(modifier: Modifier, type: NotiType, date: LocalDateTime) {
+    val labelModifier = Modifier
+        .background(
+            color = WishBoardTheme.colors.green500,
+            shape = RoundedCornerShape(16.dp),
+        )
+        .padding(vertical = 4.dp, horizontal = 8.dp)
+
+    Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            modifier = labelModifier,
+            text = type.str,
+            style = WishBoardTheme.typography.suitB5,
+            color = WishBoardTheme.colors.gray700,
+        )
+        Text(
+            modifier = labelModifier,
+            text = date.toString(), // TODO 시간 포맷 적용
+            style = WishBoardTheme.typography.suitB5,
+            color = WishBoardTheme.colors.gray700,
+        )
+    }
+}
+
+@Composable
+private fun FolderGuideString() {
+    val spanStrings = listOf(
+        WishBoardString.SpanString(value = stringResource(id = R.string.wish_item_detail_folder_guild)),
+        WishBoardString.NormalString(value = " >"),
+    )
+
+    Text(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .noRippleClickable { /*TODO*/ },
+        text = buildStringWithSpans(
+            spanStrings = spanStrings,
+            spanStyle = SpanStyle(textDecoration = TextDecoration.Underline),
+        ),
+        style = WishBoardTheme.typography.suitD3,
+        color = WishBoardTheme.colors.gray300,
+    )
+}
+
+@Preview
+@Composable
+fun PreviewWishItemDetailScreen() {
+    WishItemDetailScreen(
+        itemDetail = WishItemDetail(
+            id = 1L,
+            name = "21SS SAGE SHIRT [4COLOR]",
+            image = "https://url.kr/8vwf1e",
+            price = 108000,
+            notiDate = LocalDateTime.now(),
+            notiType = NotiType.RESTOCK,
+            site = "https://www.naver.com/",
+            memo = "S사이즈",
+            folderId = 1L,
+            folderName = "상의",
+            createAt = "1주 전",
+        ),
+    ) // TODO 시간 포맷 적용
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
@@ -54,6 +54,7 @@ fun WishItemDetailScreen(itemDetail: WishItemDetail) {
         }) { paddingValues ->
             Column(
                 modifier = Modifier
+                    .background(WishBoardTheme.colors.white)
                     .padding(top = paddingValues.calculateTopPadding()),
             ) {
                 WishItemDetailContents(modifier = Modifier.weight(1f), itemDetail = itemDetail)

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/PriceText.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/PriceText.kt
@@ -1,0 +1,28 @@
+package com.hyeeyoung.wishboard.presentation.wish.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.util.extension.setPriceFormat
+
+@Composable
+fun PriceText(modifier: Modifier = Modifier, price: Int, priceStyle: TextStyle, wonStyle: TextStyle) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = price.setPriceFormat(),
+            style = priceStyle,
+            color = WishBoardTheme.colors.gray700,
+        )
+        Text(
+            text = stringResource(id = R.string.won),
+            style = wonStyle,
+            color = WishBoardTheme.colors.gray700,
+        )
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
@@ -2,10 +2,8 @@ package com.hyeeyoung.wishboard.presentation.wish.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,25 +15,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.CartButton
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.domain.model.WishItem
-import com.hyeeyoung.wishboard.presentation.util.extension.setPriceFormat
 
 @Composable
 fun WishItem(wishItem: WishItem) {
     Column {
         var cartState by remember { mutableStateOf(wishItem.isInCart) }
         // 이미지 및 장바구니 버튼
-        Box {
+        Box() {
             ColoredImage(
                 model = wishItem.imageUrl,
                 modifier = Modifier
-                    .fillMaxSize()
+                    .fillMaxWidth()
                     .aspectRatio(1f),
             )
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
@@ -55,18 +55,12 @@ fun WishItem(wishItem: WishItem) {
         ) {
             Text(text = wishItem.name, style = WishBoardTheme.typography.suitD3, color = WishBoardTheme.colors.gray700)
             Spacer(modifier = Modifier.size(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = wishItem.price.setPriceFormat(),
-                    style = WishBoardTheme.typography.montserratH3,
-                    color = WishBoardTheme.colors.gray700,
-                )
-                Text(
-                    text = stringResource(id = R.string.won),
-                    style = WishBoardTheme.typography.suitD3,
-                    color = WishBoardTheme.colors.gray700,
-                )
-            }
+            PriceText(
+                price = wishItem.price,
+                priceStyle = WishBoardTheme.typography.montserratH3,
+                wonStyle = WishBoardTheme.typography.suitD3,
+            )
         }
     }
 }
+

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
@@ -1,0 +1,76 @@
+package com.hyeeyoung.wishboard.presentation.wish.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.button.CartButton
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.domain.model.WishItem
+import com.hyeeyoung.wishboard.presentation.util.extension.setPriceFormat
+
+@Composable
+fun WishItem(wishItem: WishItem) {
+    Column {
+        var cartState by remember { mutableStateOf(wishItem.isInCart) }
+        // 이미지 및 장바구니 버튼
+        Box {
+            ColoredImage(
+                model = wishItem.imageUrl,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .aspectRatio(1f),
+            )
+
+            Column(
+                modifier = Modifier
+                    .padding(10.dp)
+                    .align(Alignment.BottomEnd),
+            ) {
+                CartButton(
+                    isInCart = cartState,
+                    changeCartState = { isInCart -> cartState = !isInCart },
+                )
+            }
+        }
+
+        // 상품명 및 가격
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 10.dp, end = 10.dp, top = 10.dp, bottom = 20.dp),
+        ) {
+            Text(text = wishItem.name, style = WishBoardTheme.typography.suitD3, color = WishBoardTheme.colors.gray700)
+            Spacer(modifier = Modifier.size(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = wishItem.price.setPriceFormat(),
+                    style = WishBoardTheme.typography.montserratH3,
+                    color = WishBoardTheme.colors.gray700,
+                )
+                Text(
+                    text = stringResource(id = R.string.won),
+                    style = WishBoardTheme.typography.suitD3,
+                    color = WishBoardTheme.colors.gray700,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
@@ -64,3 +64,16 @@ fun WishItem(wishItem: WishItem) {
     }
 }
 
+@Preview(showBackground = true, backgroundColor = 0xffffff, widthDp = 187, heightDp = 257)
+@Composable
+fun PreviewWishItem() {
+    WishItem(
+        wishItem = WishItem(
+            1L,
+            "21SS SAGE SHIRT [4COLOR]",
+            "https://url.kr/8vwf1e",
+            108000,
+            true,
+        ),
+    )
+}

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3.851,16.075L7.925,20.149L19.247,8.831L15.169,4.753L3.851,16.075ZM2.017,21.428C1.927,21.791 2.209,22.073 2.572,21.983L7.925,20.149L3.851,16.075L2.017,21.428ZM21.059,2.942C19.251,1.131 17.437,2.489 17.437,2.489C17.14,2.715 16.078,3.847 16.078,3.847L20.153,7.922C20.153,7.922 21.281,6.86 21.511,6.564C21.511,6.564 22.869,4.757 21.059,2.942Z"
+      android:fillColor="#292929"/>
+  <path
+      android:pathData="M2.4,20.4H21.2C21.642,20.4 22,20.758 22,21.2V21.2C22,21.642 21.642,22 21.2,22H2.4V20.4Z"
+      android:fillColor="#292929"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,8 +36,15 @@
     <string name="sign_up_password_format_error">8자리 이상의 영문자, 숫자, 특수 문자 조합으로 입력해주세요.</string>
     <string name="sign_up_terms">가입 시 <b>이용약관</b>과 <b>개인정보 처리방침</b>에 동의하는 것으로 간주합니다.</string>
 
+    <!-- WishItem Global -->
+    <string name="memo">메모</string>
+
     <!-- WishItem -->
     <string name="cart_btn_text">Cart</string>
+
+    <!-- WishItemDetail -->
+    <string name="wish_item_detail_folder_guild">폴더를 지정해 보세요!</string>
+    <string name="wish_item_detail_go_to_shop">쇼핑몰로 이동하기</string>
 
     <!-- Navigation Menu -->
     <string name="nav_menu_label_wishlist">WISHLIST</string>


### PR DESCRIPTION
## What is this PR? 🔍
- closed #13

## Key Changes 🔑
1. 위시아이템 디테일 화면 UI 구현
   - **PriceText** 컴포저블 만듦 // 가격 텍스트 컴포저블 재사용 가능성을 고려
2. WishlistScreen(기존 HomeScreen)을 **wishlist 패키지로 이동** // WishItemDetailScreen과 동일 패키지에 위치시키기 위함
   - HomeScreen - WishlistScreen으로 네이밍 변경 + 그 외 변수 및 함수명을 **home -> wishlist로 네이밍 변경**
3. **Wishlist 컴포저블 추출** // 폴더 디테일 화면에서의 재사용 가능성을 고려

<img width="202" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/a9c2777f-8f28-4ea0-8a2c-14e31a51791b">

## To Reviewers 📢
- 날짜 포맷의 경우 ux writing 변경 가능성이 있어 확정된 후에 포맷 적용할 예정
- 화면 이동은 이동 대상 화면이 구현된 후에 클릭 이벤트 핸들링 예정
- 알럿 UI는 별도로 이슈 생성 후 한번에 구현할 예정
