### PR TITLE
장바구니 UI 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,9 +30,7 @@ import com.hyeeyoung.wishboard.designsystem.component.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
-import com.hyeeyoung.wishboard.designsystem.util.buildStringWithSpans
 import com.hyeeyoung.wishboard.presentation.model.CartItem
-import com.hyeeyoung.wishboard.presentation.model.WishBoardString
 import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
 import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
 
@@ -117,18 +114,6 @@ fun ItemCountController(count: Int) {
 
 @Composable
 fun CartTotalDisplay(totalCount: Int, totalPrice: Int) {
-    val spanStrings = listOf(
-        WishBoardString.NormalString("${stringResource(id = R.string.total)} "),
-        WishBoardString.SpanString("$totalCount"),
-        WishBoardString.NormalString(" ${stringResource(id = R.string.ea)}"),
-    )
-    val spanStyle = WishBoardTheme.typography.montserratH2.run {
-        SpanStyle(
-            fontSize = fontSize,
-            fontFamily = fontFamily,
-            fontWeight = fontWeight,
-        )
-    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -137,12 +122,26 @@ fun CartTotalDisplay(totalCount: Int, totalPrice: Int) {
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            // TODO text aline 적용
-            text = buildStringWithSpans(spanStrings = spanStrings, spanStyle = spanStyle),
-            style = WishBoardTheme.typography.suitD2,
-            color = WishBoardTheme.colors.gray700,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                modifier = Modifier.padding(end = 2.dp),
+                text = stringResource(id = R.string.total),
+                style = WishBoardTheme.typography.suitD2,
+                color = WishBoardTheme.colors.gray700,
+            )
+            Text(
+                text = "$totalCount",
+                style = WishBoardTheme.typography.montserratH2,
+                color = WishBoardTheme.colors.gray700,
+            )
+            Text(
+                modifier = Modifier.padding(start = 2.dp),
+                text = stringResource(id = R.string.ea),
+                style = WishBoardTheme.typography.suitD2,
+                color = WishBoardTheme.colors.gray700,
+            )
+        }
+
         PriceText(
             price = totalPrice,
             priceStyle = WishBoardTheme.typography.montserratH2,

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -1,0 +1,192 @@
+package com.hyeeyoung.wishboard.presentation.cart
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
+import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.designsystem.util.buildStringWithSpans
+import com.hyeeyoung.wishboard.presentation.model.CartItem
+import com.hyeeyoung.wishboard.presentation.model.WishBoardString
+import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
+import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
+
+@Composable
+fun CartScreen(cartItems: List<CartItem> = emptyList()) {
+    Scaffold(topBar = {
+        WishBoardTopBar(
+            topBarModel = WishBoardTopBarModel(title = stringResource(id = R.string.cart)),
+        )
+    }) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(WishBoardTheme.colors.white)
+                .padding(top = paddingValues.calculateTopPadding()),
+        ) {
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+            ) {
+                itemsIndexed(cartItems) { idx, item ->
+                    CartItem(cartItem = item)
+                    if (idx < cartItems.lastIndex) WishBoardDivider()
+                }
+            }
+
+            CartTotalDisplay(totalCount = cartItems.size, totalPrice = 180000)
+        }
+    }
+}
+
+@Composable
+fun CartItem(cartItem: CartItem) {
+    val imageSize = 84
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        ColoredImage(
+            model = cartItem.image,
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, bottom = 16.dp)
+                .size(imageSize.dp)
+                .clip(RoundedCornerShape(10.dp)),
+        )
+        Column(modifier = Modifier.height((imageSize + 32).dp), verticalArrangement = Arrangement.SpaceBetween) {
+            Row() {
+                Text(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 10.dp, top = 16.dp),
+                    text = cartItem.name,
+                    style = WishBoardTheme.typography.suitD2M,
+                    color = WishBoardTheme.colors.gray700,
+                )
+                Surface(modifier = Modifier.padding(top = 6.dp, end = 4.dp)) {
+                    WishBoardIconButton(iconRes = R.drawable.ic_delete_small_gray, onClick = { /*TODO*/ })
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                ItemCountController(cartItem.count)
+                PriceText(
+                    modifier = Modifier.padding(end = 16.dp, bottom = 16.dp),
+                    price = cartItem.price,
+                    priceStyle = WishBoardTheme.typography.montserratH2,
+                    wonStyle = WishBoardTheme.typography.suitD2,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ItemCountController(count: Int) {
+    Row(modifier = Modifier.padding(start = 2.dp, bottom = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+        WishBoardIconButton(iconRes = R.drawable.ic_cart_minus, onClick = { /*TODO*/ })
+        Text(modifier = Modifier.width(18.dp), text = count.toString(), textAlign = TextAlign.Center)
+        WishBoardIconButton(iconRes = R.drawable.ic_cart_plus, onClick = { /*TODO*/ })
+    }
+}
+
+@Composable
+fun CartTotalDisplay(totalCount: Int, totalPrice: Int) {
+    val spanStrings = listOf(
+        WishBoardString.NormalString("${stringResource(id = R.string.total)} "),
+        WishBoardString.SpanString("$totalCount"),
+        WishBoardString.NormalString(" ${stringResource(id = R.string.ea)}"),
+    )
+    val spanStyle = WishBoardTheme.typography.montserratH2.run {
+        SpanStyle(
+            fontSize = fontSize,
+            fontFamily = fontFamily,
+            fontWeight = fontWeight,
+        )
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(WishBoardTheme.colors.green500)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            // TODO text aline 적용
+            text = buildStringWithSpans(spanStrings = spanStrings, spanStyle = spanStyle),
+            style = WishBoardTheme.typography.suitD2,
+            color = WishBoardTheme.colors.gray700,
+        )
+        PriceText(
+            price = totalPrice,
+            priceStyle = WishBoardTheme.typography.montserratH2,
+            wonStyle = WishBoardTheme.typography.suitD2,
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PreviewCartScreen() {
+    val cartItem = listOf(
+        CartItem(
+            id = 1L,
+            name = "Bean Ring Gold",
+            image = "https://url.kr/8vwf1e",
+            price = 108000,
+            count = 1,
+        ),
+    )
+    val cartItems = List(7) { cartItem }.flatten()
+
+    CartScreen(
+        cartItems = cartItems,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewCartItem() {
+    val cartItem = CartItem(
+        id = 1L,
+        name = "Bean Ring Gold",
+        image = "https://url.kr/8vwf1e",
+        price = 108000,
+        1,
+    )
+
+    Column() {
+        CartItem(
+            cartItem = cartItem,
+        )
+        CartItem(
+            cartItem = cartItem.copy(count = 88),
+        )
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/model/CartItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/model/CartItem.kt
@@ -1,0 +1,9 @@
+package com.hyeeyoung.wishboard.presentation.model
+
+data class CartItem(
+    val id: Long,
+    val name: String,
+    val image: String,
+    val price: Int,
+    var count: Int,
+)

--- a/app/src/main/res/drawable/ic_cart_minus.xml
+++ b/app/src/main/res/drawable/ic_cart_minus.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="23dp"
+    android:height="23dp"
+    android:viewportWidth="23"
+    android:viewportHeight="23">
+  <path
+      android:pathData="M11.5,11.5m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#e3e3e3"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8,11.635L15.27,11.635"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#292929"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_cart_plus.xml
+++ b/app/src/main/res/drawable/ic_cart_plus.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="23dp"
+    android:height="23dp"
+    android:viewportWidth="23"
+    android:viewportHeight="23">
+  <path
+      android:pathData="M11.5,11.5m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#e3e3e3"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11.635,8L11.635,15.27"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#292929"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8,11.635L15.27,11.635"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#292929"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_delete_small_gray.xml
+++ b/app/src/main/res/drawable/ic_delete_small_gray.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="24dp"
+    android:viewportWidth="25"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M17.8,6.7L7.2,17.3"
+      android:strokeWidth="1.6"
+      android:fillColor="#00000000"
+      android:strokeColor="#CACACA"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M7.2,6.7L17.8,17.3"
+      android:strokeWidth="1.6"
+      android:fillColor="#00000000"
+      android:strokeColor="#CACACA"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,11 @@
     <string name="wish_item_detail_folder_guild">폴더를 지정해 보세요!</string>
     <string name="wish_item_detail_go_to_shop">쇼핑몰로 이동하기</string>
 
+    <!-- Cart -->
+    <string name="cart">장바구니</string>
+    <string name="total">전체</string>
+    <string name="ea">개</string>
+
     <!-- Navigation Menu -->
     <string name="nav_menu_label_wishlist">WISHLIST</string>
     <string name="nav_menu_label_folder">FOLDER</string>


### PR DESCRIPTION
## What is this PR? 🔍
- closed #15

## Key Changes 🔑
1. 장바구니 UI 구현

<img width="267" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/e799ee18-0ffe-4177-9bb3-801ec18262a6">

## To Reviewers 📢
- 추후 장바구니 데이터 가져오기 api 연동 후 총 가격 계산 로직 구현 예정
