### PR TITLE
폴더 디테일 UI 구현 및 화면 전환 처리

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/BottomBarNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/BottomBarNavHost.kt
@@ -6,7 +6,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.hyeeyoung.wishboard.config.navigation.screen.Main
-import com.hyeeyoung.wishboard.presentation.folder.FolderScreen
 import com.hyeeyoung.wishboard.presentation.wish.WishlistScreen
 
 @Composable
@@ -15,9 +14,9 @@ fun BottomBarNavHost(modifier: Modifier = Modifier, navController: NavHostContro
         composable(route = Main.Wishlist.route) {
             WishlistScreen()
         }
-        composable(route = Main.Folder.route) {
-            FolderScreen()
-        }
+
+        folderNavGraph(navController)
+
         composable(route = Main.Add.route) {
             /** TODO */
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/FolderNavGraph.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/FolderNavGraph.kt
@@ -18,7 +18,7 @@ fun NavGraphBuilder.folderNavGraph(navController: NavHostController) =
 
         with(Main.FolderDetail) {
             composable(
-                route = "$route/{$ARG_FOLDER_ID}/{$ARG_FOLDER_NAME}",
+                route = "${Main.FolderDetail.route}/{$ARG_FOLDER_ID}/{$ARG_FOLDER_NAME}",
                 arguments = listOf(
                     navArgument(ARG_FOLDER_ID) { type = NavType.LongType },
                     navArgument(ARG_FOLDER_NAME) { type = NavType.StringType },
@@ -26,7 +26,8 @@ fun NavGraphBuilder.folderNavGraph(navController: NavHostController) =
             ) { backStackEntry ->
                 backStackEntry.arguments?.let {
                     val id = it.getLong(ARG_FOLDER_ID)
-                    val name = it.getString(ARG_FOLDER_NAME) ?: throw NullPointerException("폴더명이 존재하지 않습니다.")
+                    val name =
+                        it.getString(ARG_FOLDER_NAME) ?: throw NullPointerException("폴더명이 존재하지 않습니다.")
                     FolderDetailScreen(navController = navController, folderId = id, folderName = name)
                 }
             }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/FolderNavGraph.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/FolderNavGraph.kt
@@ -1,0 +1,34 @@
+package com.hyeeyoung.wishboard.config.navigation.navgraph
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import androidx.navigation.navArgument
+import com.hyeeyoung.wishboard.config.navigation.screen.Main
+import com.hyeeyoung.wishboard.presentation.folder.FolderDetailScreen
+import com.hyeeyoung.wishboard.presentation.folder.FolderScreen
+
+fun NavGraphBuilder.folderNavGraph(navController: NavHostController) =
+    navigation(startDestination = Main.Folder.makeStartRoute(), route = Main.Folder.route) {
+        composable(route = Main.Folder.makeStartRoute()) {
+            FolderScreen(navController = navController)
+        }
+
+        with(Main.FolderDetail) {
+            composable(
+                route = "$route/{$ARG_FOLDER_ID}/{$ARG_FOLDER_NAME}",
+                arguments = listOf(
+                    navArgument(ARG_FOLDER_ID) { type = NavType.LongType },
+                    navArgument(ARG_FOLDER_NAME) { type = NavType.StringType },
+                ),
+            ) { backStackEntry ->
+                backStackEntry.arguments?.let {
+                    val id = it.getLong(ARG_FOLDER_ID)
+                    val name = it.getString(ARG_FOLDER_NAME) ?: throw NullPointerException("폴더명이 존재하지 않습니다.")
+                    FolderDetailScreen(navController = navController, folderId = id, folderName = name)
+                }
+            }
+        }
+    }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/FolderNavGraph.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navgraph/FolderNavGraph.kt
@@ -18,7 +18,7 @@ fun NavGraphBuilder.folderNavGraph(navController: NavHostController) =
 
         with(Main.FolderDetail) {
             composable(
-                route = "${Main.FolderDetail.route}/{$ARG_FOLDER_ID}/{$ARG_FOLDER_NAME}",
+                route = routeWithArg,
                 arguments = listOf(
                     navArgument(ARG_FOLDER_ID) { type = NavType.LongType },
                     navArgument(ARG_FOLDER_NAME) { type = NavType.StringType },

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
@@ -34,7 +34,7 @@ fun BottomBarNavHost(modifier: Modifier = Modifier, navController: NavHostContro
 
         with(Main.WishItemDetail) {
             composable(
-                route = "$route/{$ARG_WISH_ITEM_ID}",
+                route = routeWithArg,
                 arguments = listOf(navArgument(ARG_WISH_ITEM_ID) { type = NavType.LongType }),
             ) { backStackEntry ->
                 backStackEntry.arguments?.let {

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
@@ -39,7 +39,7 @@ fun BottomBarNavHost(modifier: Modifier = Modifier, navController: NavHostContro
             ) { backStackEntry ->
                 backStackEntry.arguments?.let {
                     val itemId = it.getLong(ARG_WISH_ITEM_ID)
-                    WishItemDetailScreen(itemId = itemId)
+                    WishItemDetailScreen(navController, itemId = itemId)
                 }
             }
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
@@ -1,10 +1,11 @@
-package com.hyeeyoung.wishboard.config.navigation.navgraph
+package com.hyeeyoung.wishboard.config.navigation.navhost
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.hyeeyoung.wishboard.config.navigation.navgraph.folderNavGraph
 import com.hyeeyoung.wishboard.config.navigation.screen.Main
 import com.hyeeyoung.wishboard.presentation.wish.WishlistScreen
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/BottomBarNavHost.kt
@@ -3,12 +3,14 @@ package com.hyeeyoung.wishboard.config.navigation.navhost
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.hyeeyoung.wishboard.config.navigation.navgraph.folderNavGraph
 import com.hyeeyoung.wishboard.config.navigation.screen.Main
-import com.hyeeyoung.wishboard.presentation.folder.FolderScreen
 import com.hyeeyoung.wishboard.presentation.noti.NotiScreen
+import com.hyeeyoung.wishboard.presentation.wish.WishItemDetailScreen
 import com.hyeeyoung.wishboard.presentation.wish.WishlistScreen
 
 @Composable
@@ -28,6 +30,18 @@ fun BottomBarNavHost(modifier: Modifier = Modifier, navController: NavHostContro
         }
         composable(route = Main.My.route) {
             /** TODO */
+        }
+
+        with(Main.WishItemDetail) {
+            composable(
+                route = "$route/{$ARG_WISH_ITEM_ID}",
+                arguments = listOf(navArgument(ARG_WISH_ITEM_ID) { type = NavType.LongType }),
+            ) { backStackEntry ->
+                backStackEntry.arguments?.let {
+                    val itemId = it.getLong(ARG_WISH_ITEM_ID)
+                    WishItemDetailScreen(itemId = itemId)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/WishBoardNavHost.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/navhost/WishBoardNavHost.kt
@@ -1,10 +1,11 @@
-package com.hyeeyoung.wishboard.config.navigation.navgraph
+package com.hyeeyoung.wishboard.config.navigation.navhost
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.hyeeyoung.wishboard.config.navigation.navgraph.signNavGraph
 import com.hyeeyoung.wishboard.config.navigation.screen.Intro
 import com.hyeeyoung.wishboard.config.navigation.screen.Main
 import com.hyeeyoung.wishboard.presentation.intro.IntroScreen

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
@@ -1,15 +1,20 @@
 package com.hyeeyoung.wishboard.config.navigation.screen
 
+import com.hyeeyoung.wishboard.config.navigation.screen.Main.FolderDetail.ARG_FOLDER_ID
+import com.hyeeyoung.wishboard.config.navigation.screen.Main.FolderDetail.ARG_FOLDER_NAME
+
 sealed class Main(override val route: String) : Screen {
     object Root : Main(route = "mainRoot")
     object Wishlist : Main(route = "wishlist")
     object WishItemDetail : Main(route = "wishItemDetail") {
         const val ARG_WISH_ITEM_ID: String = "wishItemId"
+        val routeWithArg = "$route/{$ARG_WISH_ITEM_ID}"
     }
     object Folder : Main(route = "folder")
     object FolderDetail : Main(route = "folderDetail") {
         const val ARG_FOLDER_ID: String = "folderId"
         const val ARG_FOLDER_NAME: String = "folderName"
+        val routeWithArg = "$route/{$ARG_FOLDER_ID}/{$ARG_FOLDER_NAME}"
     }
     object Add : Main(route = "add")
     object Noti : Main(route = "noti")

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
@@ -4,7 +4,17 @@ sealed class Main(override val route: String) : Screen {
     object Root : Main(route = "mainRoot")
     object Wishlist : Main(route = "wishlist")
     object Folder : Main(route = "folder")
+    object FolderDetail : Main(route = "folderDetail") {
+        const val ARG_FOLDER_ID: String = "folderId"
+        const val ARG_FOLDER_NAME: String = "folderName"
+    }
     object Add : Main(route = "add")
     object Noti : Main(route = "noti")
     object My : Main(route = "my")
+
+    /** NavGraphBuilder.navigation() 사용 시 파라미터 route + "start" 문자열을 합성해서 startDestination 경로를 만듦   */
+    fun makeStartRoute() = when (this) {
+        Wishlist, Folder, Add, Noti, My -> this.route + "Start"
+        else -> throw IllegalStateException("루트 경로가 될 수 없음.")
+    }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/config/navigation/screen/Main.kt
@@ -3,6 +3,9 @@ package com.hyeeyoung.wishboard.config.navigation.screen
 sealed class Main(override val route: String) : Screen {
     object Root : Main(route = "mainRoot")
     object Wishlist : Main(route = "wishlist")
+    object WishItemDetail : Main(route = "wishItemDetail") {
+        const val ARG_WISH_ITEM_ID: String = "wishItemId"
+    }
     object Folder : Main(route = "folder")
     object FolderDetail : Main(route = "folderDetail") {
         const val ARG_FOLDER_ID: String = "folderId"

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
@@ -35,7 +35,12 @@ fun FolderDetailScreen(navController: NavHostController, folderId: Long, folderN
 
     WishboardTheme {
         Scaffold(topBar = {
-            WishBoardTopBar(topBarModel = WishBoardTopBarModel(title = folderName))
+            WishBoardTopBar(
+                topBarModel = WishBoardTopBarModel(
+                    title = folderName,
+                    onClickStartIcon = { navController.popBackStack() },
+                ),
+            )
         }) { paddingValues ->
             LazyVerticalGrid(
                 modifier = Modifier

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
@@ -11,16 +11,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.hyeeyoung.wishboard.config.navigation.screen.Main
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 import com.hyeeyoung.wishboard.domain.model.WishItem
 import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
+import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 import com.hyeeyoung.wishboard.presentation.wish.component.WishItem
 
 @Composable
 fun FolderDetailScreen(navController: NavHostController, folderId: Long, folderName: String) {
-    val wishList = listOf(
+    val wishItem = listOf(
         WishItem(
             1L,
             "21SS SAGE SHIRT [4COLOR]",
@@ -28,42 +30,9 @@ fun FolderDetailScreen(navController: NavHostController, folderId: Long, folderN
             108000,
             true,
         ),
-        WishItem(
-            1L,
-            "SOFT BALL CHAIN MINI BAG [SILVER]",
-            "https://url.kr/8vwf1e",
-            108000,
-            false,
-        ),
-        WishItem(
-            1L,
-            "썸머호텔 여름차렵이불세트",
-            "https://url.kr/8vwf1e",
-            108000,
-            false,
-        ),
-        WishItem(
-            1L,
-            "Bean Ring Gold",
-            "https://url.kr/8vwf1e",
-            108000,
-            true,
-        ),
-        WishItem(
-            1L,
-            "Bean Ring Gold",
-            "https://url.kr/8vwf1e",
-            108000,
-            false,
-        ),
-        WishItem(
-            1L,
-            "Bean Ring Gold",
-            "https://url.kr/8vwf1e",
-            108000,
-            false,
-        ),
     )
+    val wishList = List(8) { wishItem }.flatten() // TODO 서버 연동 후 삭제
+
     WishboardTheme {
         Scaffold(topBar = {
             WishBoardTopBar(topBarModel = WishBoardTopBarModel(title = folderName))
@@ -76,7 +45,14 @@ fun FolderDetailScreen(navController: NavHostController, folderId: Long, folderN
                     ),
                 columns = GridCells.Fixed(2),
             ) {
-                items(wishList) { wishItem -> WishItem(wishItem = wishItem) }
+                items(wishList) { wishItem ->
+                    WishItem(
+                        modifier = Modifier.noRippleClickable {
+                            navController.navigate("${Main.WishItemDetail.route}/${wishItem.id}")
+                        },
+                        wishItem = wishItem,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
@@ -1,0 +1,89 @@
+package com.hyeeyoung.wishboard.presentation.folder
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
+import com.hyeeyoung.wishboard.domain.model.WishItem
+import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
+import com.hyeeyoung.wishboard.presentation.wish.component.WishItem
+
+@Composable
+fun FolderDetailScreen(navController: NavHostController, folderId: Long, folderName: String) {
+    val wishList = listOf(
+        WishItem(
+            1L,
+            "21SS SAGE SHIRT [4COLOR]",
+            "https://url.kr/8vwf1e",
+            108000,
+            true,
+        ),
+        WishItem(
+            1L,
+            "SOFT BALL CHAIN MINI BAG [SILVER]",
+            "https://url.kr/8vwf1e",
+            108000,
+            false,
+        ),
+        WishItem(
+            1L,
+            "썸머호텔 여름차렵이불세트",
+            "https://url.kr/8vwf1e",
+            108000,
+            false,
+        ),
+        WishItem(
+            1L,
+            "Bean Ring Gold",
+            "https://url.kr/8vwf1e",
+            108000,
+            true,
+        ),
+        WishItem(
+            1L,
+            "Bean Ring Gold",
+            "https://url.kr/8vwf1e",
+            108000,
+            false,
+        ),
+        WishItem(
+            1L,
+            "Bean Ring Gold",
+            "https://url.kr/8vwf1e",
+            108000,
+            false,
+        ),
+    )
+    WishboardTheme {
+        Scaffold(topBar = {
+            WishBoardTopBar(topBarModel = WishBoardTopBarModel(title = folderName))
+        }) { paddingValues ->
+            LazyVerticalGrid(
+                modifier = Modifier
+                    .background(WishBoardTheme.colors.white)
+                    .padding(
+                        top = paddingValues.calculateTopPadding(),
+                    ),
+                columns = GridCells.Fixed(2),
+            ) {
+                items(wishList) { wishItem -> WishItem(wishItem = wishItem) }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun PreviewFolderDetailScreen() {
+    FolderDetailScreen(navController = rememberNavController(), folderId = 1L, folderName = "상의")
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
@@ -22,7 +22,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.config.navigation.screen.Main
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
@@ -31,7 +34,17 @@ import com.hyeeyoung.wishboard.presentation.model.Folder
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 
 @Composable
-fun FolderScreen(folders: List<Folder> = emptyList()) {
+fun FolderScreen(navController: NavHostController) {
+    val folder = listOf(
+        Folder(
+            id = 1L,
+            name = "아우터",
+            thumbnail = "https://url.kr/8vwf1e",
+            itemCount = 1,
+        ),
+    )
+    val folders = List(8) { folder }.flatten() // TODO 서버 연동 후 삭제
+
     Scaffold(topBar = {
         WishBoardMainTopBar(
             titleRes = R.string.folder,
@@ -55,7 +68,12 @@ fun FolderScreen(folders: List<Folder> = emptyList()) {
                 columns = GridCells.Fixed(2),
             ) {
                 items(folders) { folder ->
-                    FolderItem(folder = folder)
+                    FolderItem(
+                        folder = folder,
+                        onClickFolder = { folderId ->
+                            navController.navigate("${Main.FolderDetail.route}/$folderId/${folder.name}")
+                        },
+                    )
                 }
             }
         }
@@ -63,8 +81,12 @@ fun FolderScreen(folders: List<Folder> = emptyList()) {
 }
 
 @Composable
-fun FolderItem(folder: Folder) {
-    Column(modifier = Modifier.padding(horizontal = 8.dp)) {
+fun FolderItem(folder: Folder, onClickFolder: (Long) -> Unit) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 8.dp)
+            .noRippleClickable { onClickFolder(folder.id) },
+    ) {
         ColoredImage(
             model = folder.thumbnail,
             modifier = Modifier
@@ -106,17 +128,7 @@ fun FolderItem(folder: Folder) {
 @Composable
 @Preview
 fun PreviewFolderScreen() {
-    val folder = listOf(
-        Folder(
-            id = 1L,
-            name = "Bean Ring Gold",
-            thumbnail = "https://url.kr/8vwf1e",
-            itemCount = 1,
-        ),
-    )
-    val folders = List(8) { folder }.flatten()
-
-    FolderScreen(folders)
+    FolderScreen(navController = rememberNavController())
 }
 
 @Preview(showBackground = true)
@@ -131,5 +143,6 @@ fun PreviewFolderItem() {
 
     FolderItem(
         folder = folder,
+        onClickFolder = {},
     )
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/main/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.hyeeyoung.wishboard.config.navigation.navgraph.WishBoardNavHost
+import com.hyeeyoung.wishboard.config.navigation.navhost.WishBoardNavHost
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/main/MainScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
-import com.hyeeyoung.wishboard.config.navigation.navgraph.BottomBarNavHost
+import com.hyeeyoung.wishboard.config.navigation.navhost.BottomBarNavHost
 import com.hyeeyoung.wishboard.designsystem.component.bottombar.WishBoardBottomBar
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/main/MainScreen.kt
@@ -3,10 +3,14 @@ package com.hyeeyoung.wishboard.presentation.main
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.config.navigation.navhost.BottomBarNavHost
+import com.hyeeyoung.wishboard.config.navigation.screen.Main
 import com.hyeeyoung.wishboard.designsystem.component.bottombar.WishBoardBottomBar
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 
@@ -15,10 +19,24 @@ fun MainScreen() {
     val navController = rememberNavController()
 
     Scaffold(bottomBar = {
-        WishBoardBottomBar(navController = navController)
+        if (isVisibleBottomBar(navController)) WishBoardBottomBar(navController = navController)
     }) { paddingValues ->
         val modifier = Modifier.padding(bottom = paddingValues.calculateBottomPadding())
         BottomBarNavHost(modifier = modifier, navController = navController)
+    }
+}
+
+@Composable
+fun isVisibleBottomBar(navController: NavHostController): Boolean {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    return when (navBackStackEntry?.destination?.route) {
+        Main.Wishlist.route,
+        Main.Folder.makeStartRoute(),
+        Main.Add.route, Main.Noti.route,
+        Main.My.route,
+        Main.FolderDetail.routeWithArg,
+        -> true
+        else -> false
     }
 }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
@@ -44,7 +44,21 @@ import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
 import java.time.LocalDateTime
 
 @Composable
-fun WishItemDetailScreen(itemDetail: WishItemDetail) {
+fun WishItemDetailScreen(itemId: Long) {
+    val itemDetail = WishItemDetail(
+        id = 1L,
+        name = "21SS SAGE SHIRT [4COLOR]",
+        image = "https://url.kr/8vwf1e",
+        price = 108000,
+        notiDate = LocalDateTime.now(),
+        notiType = NotiType.RESTOCK,
+        site = "https://www.naver.com/",
+        memo = "S사이즈",
+        folderId = 1L,
+        folderName = "상의",
+        createAt = "1주 전",
+    ) // TODO 시간 포맷 적용 및 서버 연동 시 삭제
+
     WishboardTheme { // TODO Theme 사용 여부 고려
         Scaffold(topBar = {
             WishBoardTopBar(
@@ -211,19 +225,5 @@ private fun FolderGuideString() {
 @Preview
 @Composable
 fun PreviewWishItemDetailScreen() {
-    WishItemDetailScreen(
-        itemDetail = WishItemDetail(
-            id = 1L,
-            name = "21SS SAGE SHIRT [4COLOR]",
-            image = "https://url.kr/8vwf1e",
-            price = 108000,
-            notiDate = LocalDateTime.now(),
-            notiType = NotiType.RESTOCK,
-            site = "https://www.naver.com/",
-            memo = "S사이즈",
-            folderId = 1L,
-            folderName = "상의",
-            createAt = "1주 전",
-        ),
-    ) // TODO 시간 포맷 적용
+    WishItemDetailScreen(itemId = 1L)
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.WishBoardDivider
@@ -44,7 +46,7 @@ import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
 import java.time.LocalDateTime
 
 @Composable
-fun WishItemDetailScreen(itemId: Long) {
+fun WishItemDetailScreen(navController: NavHostController, itemId: Long) {
     val itemDetail = WishItemDetail(
         id = 1L,
         name = "21SS SAGE SHIRT [4COLOR]",
@@ -62,7 +64,7 @@ fun WishItemDetailScreen(itemId: Long) {
     WishboardTheme { // TODO Theme 사용 여부 고려
         Scaffold(topBar = {
             WishBoardTopBar(
-                WishBoardTopBarModel(onClickStartIcon = { /*TODO*/ }),
+                WishBoardTopBarModel(onClickStartIcon = { navController.popBackStack() }),
                 endComponent = { modifier -> TopBarEndIcons(modifier) },
             )
         }) { paddingValues ->
@@ -225,5 +227,5 @@ private fun FolderGuideString() {
 @Preview
 @Composable
 fun PreviewWishItemDetailScreen() {
-    WishItemDetailScreen(itemId = 1L)
+    WishItemDetailScreen(navController = rememberNavController(), itemId = 1L)
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
@@ -23,8 +23,8 @@ import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.domain.model.WishItem
 
 @Composable
-fun WishItem(wishItem: WishItem) {
-    Column {
+fun WishItem(modifier: Modifier = Modifier, wishItem: WishItem) {
+    Column(modifier = modifier) {
         var cartState by remember { mutableStateOf(wishItem.isInCart) }
         // 이미지 및 장바구니 버튼
         Box() {


### PR DESCRIPTION
## What is this PR? 🔍
- closed #21

## Key Changes 🔑
1. 폴더 디테일 UI 구현
2. 폴더탭 -> 폴더 디테일 -> 아이템 디테일 화면 전환 처리 + (백버튼 클릭 이벤트 핸들링)
   - 일부 화면 전환 시 arguments 전달을 위해 경로 기존 오브젝트에 argument 관련 멤버 변수 추가
3. 아이템 디테일 화면과 같은 특정 화면에서는 BottomBar 안보이도록 분기처리
4. NavHost 컴포저블이 있는 파일을 별도 패키지로 분리

<img width="224" alt="스크린샷 2023-09-01 오후 3 11 09" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/0c7d7030-c251-4b0e-bf78-f79565a6b5d4">

## To Reviewers 📢
- 추후 상태바 컬러 화이트로 변경
