### PR TITLE
알럿 UI 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
@@ -1,0 +1,120 @@
+package com.hyeeyoung.wishboard.designsystem.component.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
+
+@Composable
+fun WishBoardDialog(
+    isOpen: Boolean,
+    textRes: WishBoardDialogTextRes,
+    isWarningDialog: Boolean = true,
+    onClickConfirm: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    if (!isOpen) return
+    Dialog(onDismissRequest = { onDismissRequest() }) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = WishBoardTheme.colors.white, shape = RoundedCornerShape(16.dp))
+                .padding(top = 24.dp), horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(textRes.titleRes),
+                style = WishBoardTheme.typography.suitH3,
+                color = WishBoardTheme.colors.gray600
+            )
+            Text(
+                modifier = Modifier.padding(top = 8.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
+                text = stringResource(textRes.descriptionRes),
+                style = WishBoardTheme.typography.suitD2M,
+                color = WishBoardTheme.colors.gray300,
+                textAlign = TextAlign.Center
+            )
+
+            WishBoardDivider()
+
+            Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+                Text(
+                    modifier = Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = rememberRipple(color = WishBoardTheme.colors.gray150)
+                        ) { onDismissRequest() }
+                        .weight(1f)
+                        .padding(vertical = 16.dp),
+                    text = stringResource(id = textRes.dismissBtnTextRes),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = WishBoardTheme.colors.gray600,
+                    textAlign = TextAlign.Center
+                )
+
+                Divider(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .fillMaxHeight(),
+                    color = WishBoardTheme.colors.gray100,
+                )
+
+                Text(
+                    modifier = Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = rememberRipple(color = WishBoardTheme.colors.gray150)
+                        ) {
+                            onClickConfirm()
+                            onDismissRequest()
+                        }
+                        .weight(1f)
+                        .padding(vertical = 16.dp),
+                    text = stringResource(id = textRes.confirmBtnTextRes),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = if (isWarningDialog) WishBoardTheme.colors.pink700 else WishBoardTheme.colors.green700,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewWishBoardDialog() {
+    WishBoardDialog(
+        isOpen = true,
+        textRes = WishBoardDialogTextRes(
+            titleRes = R.string.dialog_noti_title,
+            descriptionRes = R.string.dialog_noti_description,
+            dismissBtnTextRes = R.string.later,
+            confirmBtnTextRes = R.string.dialog_noti_confirm_btn_text,
+        ),
+        onClickConfirm = {},
+        onDismissRequest = {}
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
@@ -35,7 +35,7 @@ fun WishBoardDialog(
     textRes: WishBoardDialogTextRes,
     isWarningDialog: Boolean = true,
     onClickConfirm: () -> Unit,
-    onDismissRequest: () -> Unit
+    onDismissRequest: () -> Unit,
 ) {
     if (!isOpen) return
     Dialog(onDismissRequest = { onDismissRequest() }) {
@@ -43,19 +43,20 @@ fun WishBoardDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(color = WishBoardTheme.colors.white, shape = RoundedCornerShape(16.dp))
-                .padding(top = 24.dp), horizontalAlignment = Alignment.CenterHorizontally
+                .padding(top = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = stringResource(textRes.titleRes),
                 style = WishBoardTheme.typography.suitH3,
-                color = WishBoardTheme.colors.gray600
+                color = WishBoardTheme.colors.gray600,
             )
             Text(
                 modifier = Modifier.padding(top = 8.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
                 text = stringResource(textRes.descriptionRes),
                 style = WishBoardTheme.typography.suitD2M,
                 color = WishBoardTheme.colors.gray300,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
             )
 
             WishBoardDivider()
@@ -65,14 +66,14 @@ fun WishBoardDialog(
                     modifier = Modifier
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
-                            indication = rememberRipple(color = WishBoardTheme.colors.gray150)
+                            indication = rememberRipple(color = WishBoardTheme.colors.gray150),
                         ) { onDismissRequest() }
                         .weight(1f)
                         .padding(vertical = 16.dp),
                     text = stringResource(id = textRes.dismissBtnTextRes),
                     style = WishBoardTheme.typography.suitB3,
                     color = WishBoardTheme.colors.gray600,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
                 )
 
                 Divider(
@@ -86,7 +87,7 @@ fun WishBoardDialog(
                     modifier = Modifier
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
-                            indication = rememberRipple(color = WishBoardTheme.colors.gray150)
+                            indication = rememberRipple(color = WishBoardTheme.colors.gray150),
                         ) {
                             onClickConfirm()
                             onDismissRequest()
@@ -96,7 +97,7 @@ fun WishBoardDialog(
                     text = stringResource(id = textRes.confirmBtnTextRes),
                     style = WishBoardTheme.typography.suitB3,
                     color = if (isWarningDialog) WishBoardTheme.colors.pink700 else WishBoardTheme.colors.green700,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
                 )
             }
         }
@@ -115,6 +116,6 @@ fun PreviewWishBoardDialog() {
             confirmBtnTextRes = R.string.dialog_noti_confirm_btn_text,
         ),
         onClickConfirm = {},
-        onDismissRequest = {}
+        onDismissRequest = {},
     )
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -17,6 +17,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,11 +35,13 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
+import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Green500
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.CartItem
+import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
 import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
@@ -53,8 +59,9 @@ fun CartScreen(navController: NavHostController) {
         ),
     )
     val cartItems = List(7) { cartItem }.flatten()
-
     val systemUiController = rememberSystemUiController()
+    var isOpenDialog by remember { mutableStateOf(false) }
+
     SideEffect {
         systemUiController.setNavigationBarColor(color = Green500)
     }
@@ -80,6 +87,7 @@ fun CartScreen(navController: NavHostController) {
                         cartItem = item,
                         moveToDetail = { id -> navController.navigate("${MainScreen.WishItemDetail.route}/$id") },
                         onChangeItemCount = { count -> /*TODO*/ },
+                        onClickDelete = { id -> isOpenDialog = true },
                     )
                     if (idx < cartItems.lastIndex) WishBoardDivider()
                 }
@@ -87,11 +95,28 @@ fun CartScreen(navController: NavHostController) {
 
             CartTotalDisplay(totalCount = cartItems.size, totalPrice = cartItems.sumOf { it.price * it.count })
         }
+
+        WishBoardDialog(
+            isOpen = isOpenDialog,
+            textRes = WishBoardDialogTextRes(
+                titleRes = R.string.dialog_cart_title,
+                descriptionRes = R.string.dialog_cart_description,
+                dismissBtnTextRes = R.string.cancel,
+                confirmBtnTextRes = R.string.delete,
+            ),
+            onClickConfirm = {},
+            onDismissRequest = { isOpenDialog = false },
+        )
     }
 }
 
 @Composable
-fun CartItem(cartItem: CartItem, moveToDetail: (Long) -> Unit = {}, onChangeItemCount: (Int) -> Unit = {}) {
+fun CartItem(
+    cartItem: CartItem,
+    moveToDetail: (Long) -> Unit = {},
+    onChangeItemCount: (Int) -> Unit = {},
+    onClickDelete: (Long) -> Unit = {},
+) {
     val imageSize = 84
     Row(verticalAlignment = Alignment.CenterVertically) {
         ColoredImage(
@@ -113,8 +138,12 @@ fun CartItem(cartItem: CartItem, moveToDetail: (Long) -> Unit = {}, onChangeItem
                     style = WishBoardTheme.typography.suitD2M,
                     color = WishBoardTheme.colors.gray700,
                 )
+
                 Surface(modifier = Modifier.padding(top = 6.dp, end = 4.dp)) {
-                    WishBoardIconButton(iconRes = R.drawable.ic_delete_small_gray, onClick = { /*TODO*/ })
+                    WishBoardIconButton(
+                        iconRes = R.drawable.ic_delete_small_gray,
+                        onClick = { onClickDelete(cartItem.id) },
+                    )
                 }
             }
             Row(

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
@@ -14,6 +14,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
@@ -26,9 +30,11 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
+import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.Folder
+import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 
 @Composable
@@ -42,6 +48,7 @@ fun FolderScreen(navController: NavHostController) {
         ),
     )
     val folders = List(8) { folder }.flatten() // TODO 서버 연동 후 삭제
+    var isOpenDialog by remember { mutableStateOf(false) }
 
     Scaffold(topBar = {
         WishBoardMainTopBar(
@@ -67,14 +74,27 @@ fun FolderScreen(navController: NavHostController) {
                     onClickFolder = { folderId ->
                         navController.navigate("${MainScreen.FolderDetail.route}/$folderId/${folder.name}")
                     },
+                    onClickMore = { },
                 )
             }
         }
+
+        WishBoardDialog(
+            isOpen = isOpenDialog,
+            textRes = WishBoardDialogTextRes(
+                titleRes = R.string.dialog_folder_delete_title,
+                descriptionRes = R.string.dialog_folder_delete_description,
+                dismissBtnTextRes = R.string.cancel,
+                confirmBtnTextRes = R.string.delete,
+            ),
+            onClickConfirm = {},
+            onDismissRequest = { isOpenDialog = false },
+        )
     }
 }
 
 @Composable
-fun FolderItem(folder: Folder, onClickFolder: (Long) -> Unit) {
+fun FolderItem(folder: Folder, onClickFolder: (Long) -> Unit, onClickMore: () -> Unit) {
     Column(
         modifier = Modifier
             .padding(horizontal = 8.dp)
@@ -108,7 +128,7 @@ fun FolderItem(folder: Folder, onClickFolder: (Long) -> Unit) {
 
             Icon(
                 modifier = Modifier
-                    .noRippleClickable { /*TODO*/ }
+                    .noRippleClickable { onClickMore() }
                     .padding(start = 4.dp),
                 painter = painterResource(id = R.drawable.ic_more),
                 contentDescription = null,
@@ -137,5 +157,6 @@ fun PreviewFolderItem() {
     FolderItem(
         folder = folder,
         onClickFolder = {},
+        onClickMore = {},
     )
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/model/WishBoardDialogTextRes.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/model/WishBoardDialogTextRes.kt
@@ -1,0 +1,10 @@
+package com.hyeeyoung.wishboard.presentation.model
+
+import androidx.annotation.StringRes
+
+data class WishBoardDialogTextRes(
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+    @StringRes val dismissBtnTextRes: Int,
+    @StringRes val confirmBtnTextRes: Int,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyScreen.kt
@@ -35,9 +35,11 @@ import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.WishBoardToggleButton
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardMiniButton
+import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardThickDivider
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
 import com.hyeeyoung.wishboard.presentation.util.constant.WishBoardUrl
 import com.hyeeyoung.wishboard.presentation.util.extension.moveToWebView
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
@@ -46,7 +48,10 @@ import com.hyeeyoung.wishboard.presentation.util.extension.sendMail
 @Composable
 fun MyScreen(navController: NavHostController) {
     // TODO 클릭 이벤트 핸들링
+
     val context = LocalContext.current
+    var dialogType by remember { mutableStateOf<DialogType?>(null) }
+
     val myMenuComponents =
         listOf(
             MyMenuComponent.Divider,
@@ -102,8 +107,14 @@ fun MyScreen(navController: NavHostController) {
                 },
             ),
             MyMenuComponent.Divider,
-            MyMenuComponent.Menu(nameRes = R.string.my_menu_logout, onClickMenu = {}),
-            MyMenuComponent.Menu(nameRes = R.string.my_menu_withdraw, onClickMenu = {}),
+            MyMenuComponent.Menu(
+                nameRes = R.string.my_menu_logout,
+                onClickMenu = { dialogType = DialogType.LOGOUT },
+            ),
+            MyMenuComponent.Menu(
+                nameRes = R.string.my_menu_withdraw,
+                onClickMenu = { dialogType = DialogType.WITHDRAW },
+            ),
         )
 
     Scaffold(topBar = {
@@ -122,6 +133,16 @@ fun MyScreen(navController: NavHostController) {
                 }
             }
             item { Spacer(modifier = Modifier.size(64.dp)) }
+        }
+
+        dialogType?.let { type ->
+            WishBoardDialog(
+                isOpen = true,
+                textRes = type.dialogTextRes,
+                isWarningDialog = type.isWaringDialog,
+                onClickConfirm = {},
+                onDismissRequest = { dialogType = null },
+            )
         }
     }
 }
@@ -190,6 +211,27 @@ fun MenuItem(menu: MyMenuComponent.Menu) {
         )
         menu.endComponent?.let { endComponent -> endComponent() }
     }
+}
+
+enum class DialogType(val dialogTextRes: WishBoardDialogTextRes, val isWaringDialog: Boolean) {
+    LOGOUT(
+        WishBoardDialogTextRes(
+            titleRes = R.string.my_menu_logout,
+            descriptionRes = R.string.dialog_logout_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.my_menu_logout,
+        ),
+        true,
+    ),
+    WITHDRAW(
+        WishBoardDialogTextRes(
+            titleRes = R.string.dialog_withdraw_title,
+            descriptionRes = R.string.dialog_withdraw_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.dialog_withdraw_confirm_btn_text,
+        ),
+        true,
+    ),
 }
 
 @Composable

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishItemDetailScreen.kt
@@ -17,6 +17,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -35,11 +39,13 @@ import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen.Upload.ARG_IT
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Gray700
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
+import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
 import com.hyeeyoung.wishboard.presentation.model.WishBoardString
 import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
 import com.hyeeyoung.wishboard.presentation.model.WishItemDetail
@@ -76,6 +82,8 @@ fun WishItemDetailScreen(navController: NavHostController, itemId: Long) {
         createAt = "1주 전",
     ) // TODO 시간 포맷 적용 및 서버 연동 시 삭제
 
+    var isOpenDialog by remember { mutableStateOf(false) }
+
     WishboardTheme { // TODO Theme 사용 여부 고려
         Scaffold(topBar = {
             WishBoardTopBar(
@@ -83,6 +91,7 @@ fun WishItemDetailScreen(navController: NavHostController, itemId: Long) {
                 endComponent = { modifier ->
                     TopBarEndIcons(
                         modifier,
+                        onClickDelete = { isOpenDialog = true },
                         onClickEdit = {
                             navController.navigate(
                                 "${MainScreen.Upload.route}?$ARG_ITEM_DETAIL=${
@@ -113,6 +122,18 @@ fun WishItemDetailScreen(navController: NavHostController, itemId: Long) {
                     isGreen = false,
                 ) // TODO 비활성화 처리
             }
+
+            WishBoardDialog(
+                isOpen = isOpenDialog,
+                textRes = WishBoardDialogTextRes(
+                    titleRes = R.string.dialog_item_delete_title,
+                    descriptionRes = R.string.dialog_item_delete_description,
+                    dismissBtnTextRes = R.string.cancel,
+                    confirmBtnTextRes = R.string.delete,
+                ),
+                onClickConfirm = {},
+                onDismissRequest = { isOpenDialog = false },
+            )
         }
     }
 }
@@ -201,9 +222,9 @@ private fun WishItemDetailContents(modifier: Modifier, itemDetail: WishItemDetai
 }
 
 @Composable
-private fun TopBarEndIcons(modifier: Modifier, onClickEdit: () -> Unit) {
+private fun TopBarEndIcons(modifier: Modifier, onClickDelete: () -> Unit, onClickEdit: () -> Unit) {
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        WishBoardIconButton(iconRes = R.drawable.ic_trash, onClick = { /*TODO*/ })
+        WishBoardIconButton(iconRes = R.drawable.ic_trash, onClick = { onClickDelete() })
         WishBoardIconButton(iconRes = R.drawable.ic_edit, onClick = { onClickEdit() })
         Spacer(modifier = Modifier.size(8.dp))
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,12 @@
     <string name="save">저장</string>
     <string name="next">다음</string>
     <string name="edit">편집</string>
+    <string name="later">나중에</string>
     <string name="complete">완료</string>
+    <string name="cancel">취소</string>
+    <string name="delete">삭제</string>
+
+    <!-- Format -->
     <string name="step">%d/%d 단계</string>
     <string name="timer_format">%d:%d</string>
 
@@ -118,4 +123,30 @@
     <string name="nav_menu_label_add">ADD</string>
     <string name="nav_menu_label_notice">NOTICE</string>
     <string name="nav_menu_label_my">MY</string>
+
+    <!-- Dialog -->
+    <string name="dialog_update_title">업데이트 안내</string>
+    <string name="dialog_update_description">위시보드가 유저분들에게 더 나은 경험을\n제공하기 위해 사용성을 개선했어요!\n더 새로워진 위시보드를 만나보세요 😆</string>
+    <string name="dialog_update_confirm_btn_text">업데이트</string>
+
+    <string name="dialog_noti_title">알림 허용</string>
+    <string name="dialog_noti_description">알림을 받아보시겠어요?\n직접 등록하신 아이템의 재입고 날짜 등의\n상품 일정 알림을 받으실 거에요.</string>
+    <string name="dialog_noti_dismiss_btn_text">나중에</string>
+    <string name="dialog_noti_confirm_btn_text">허용</string>
+
+    <string name="dialog_item_delete_title">아이템 삭제</string>
+    <string name="dialog_item_delete_description">정말 아이템을 삭제하시겠어요?\n삭제된 아이템은 다시 복구할 수 없어요!</string>
+
+    <string name="dialog_cart_title">장바구니에서 삭제</string>
+    <string name="dialog_cart_description">정말 장바구니에서 아이템을 삭제하시겠어요?</string>
+
+    <string name="dialog_folder_delete_title">폴더 삭제</string>
+    <string name="dialog_folder_delete_description">정말 폴더를 삭제하시겠어요?\n폴더가 삭제되어도 아이템은 사라지지 않아요</string>
+
+    <string name="dialog_logout_description">정말 로그아웃 하시겠어요?</string>
+
+    <string name="dialog_withdraw_title">회원 탈퇴</string>
+    <string name="dialog_withdraw_description">정말 탈퇴하시겠습니까?\n탈퇴 시 앱 내 모든 데이터가 사라집니다.\n서비스를 탈퇴하시려면 이메일을 입력해 주세요.</string>
+    <string name="dialog_withdraw_confirm_btn_text">탈퇴</string>
+
 </resources>


### PR DESCRIPTION
## What is this PR? 🔍
- closed #37

## Key Changes 🔑
1. 공용 알럿 컴포저블 구현
2. 각 화면 별로 알럿 띄우기
   - 장바구니 아이템 삭제
   - 폴더 삭제
   - 아이템 삭제
   - 알림 허용
   - 업데이트 안내
   - 로그아웃
   - 회원탈퇴

<img width="334" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/25c630d6-c1b6-4e9e-ad4f-ca161336d932">
