### PR TITLE
엠티뷰 ui 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/WishBoardEmptyView.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/WishBoardEmptyView.kt
@@ -1,4 +1,4 @@
-package com.hyeeyoung.wishboard.designsystem.component.text
+package com.hyeeyoung.wishboard.designsystem.component
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/text/WishBoardEmptyText.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/text/WishBoardEmptyText.kt
@@ -1,17 +1,53 @@
 package com.hyeeyoung.wishboard.designsystem.component.text
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 
 @Composable
-fun WishBoardEmptyText(modifier: Modifier = Modifier, @StringRes guideTextRes: Int) =
-    Text(
+fun WishBoardEmptyView(modifier: Modifier = Modifier, @StringRes guideTextRes: Int, @DrawableRes iconRes: Int? = null) {
+    Column(
         modifier = modifier,
-        text = stringResource(id = guideTextRes),
-        style = WishBoardTheme.typography.suitD2M,
-        color = WishBoardTheme.colors.gray200,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        iconRes?.let { icon ->
+            Icon(painter = painterResource(id = icon), contentDescription = null, tint = Color.Unspecified)
+            Spacer(modifier = Modifier.size(20.dp))
+        }
+
+        Text(
+            text = stringResource(id = guideTextRes),
+            style = WishBoardTheme.typography.suitD2M,
+            color = WishBoardTheme.colors.gray200,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun PreviewWishBoardEmptyView() {
+    WishBoardEmptyView(
+        modifier = Modifier.fillMaxSize(),
+        guideTextRes = R.string.empty_noti_guide_text,
+        iconRes = R.drawable.ic_noti_large,
     )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/text/WishBoardEmptyText.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/text/WishBoardEmptyText.kt
@@ -1,0 +1,17 @@
+package com.hyeeyoung.wishboard.designsystem.component.text
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+
+@Composable
+fun WishBoardEmptyText(modifier: Modifier = Modifier, @StringRes guideTextRes: Int) =
+    Text(
+        modifier = modifier,
+        text = stringResource(id = guideTextRes),
+        style = WishBoardTheme.typography.suitD2M,
+        color = WishBoardTheme.colors.gray200,
+    )

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/component/CalendarSchedule.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/component/CalendarSchedule.kt
@@ -1,6 +1,5 @@
 package com.hyeeyoung.wishboard.presentation.calendar.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,12 +13,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -27,6 +23,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.style.Gray700
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.NotiItem
@@ -52,16 +49,17 @@ fun CalendarSchedule(
             style = WishBoardTheme.typography.suitH3,
         )
         if (notiItems.isEmpty()) {
-            EmptySchedule(
+            WishBoardEmptyView(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .align(Alignment.CenterHorizontally)
-                    .weight(1.0f),
+                    .weight(1f),
+                guideTextRes = R.string.empty_noti_guide_text,
+                iconRes = R.drawable.ic_noti_large,
             )
         } else {
             LazyColumn(
                 modifier = Modifier
-                    .weight(1.0f)
+                    .weight(1f)
                     .padding(top = 16.dp),
                 contentPadding = PaddingValues(bottom = 64.dp),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -74,28 +72,6 @@ fun CalendarSchedule(
                 }
             }
         }
-    }
-}
-
-@Composable
-fun EmptySchedule(modifier: Modifier) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_noti_large),
-            contentDescription = null,
-        )
-
-        Text(
-            modifier = Modifier.padding(top = 20.dp),
-            text = stringResource(id = R.string.noti_no_item_view),
-            textAlign = TextAlign.Center,
-            color = WishBoardTheme.colors.gray200,
-            style = WishBoardTheme.typography.suitB3M,
-        )
     }
 }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/component/CalendarSchedule.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/component/CalendarSchedule.kt
@@ -23,7 +23,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
-import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.style.Gray700
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.NotiItem

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/screen/CalendarScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/screen/CalendarScreen.kt
@@ -29,9 +29,7 @@ private const val INITIAL_PAGE = PAGE_COUNT / 2
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun CalendarScreen(
-    navController: NavHostController,
-) {
+fun CalendarScreen(navController: NavHostController) {
     // TODO 서버 연동 후 삭제
     val notiList = listOf(
         NotiItem(

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -34,10 +34,10 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
-import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Green500
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -37,6 +37,7 @@ import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Green500
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
@@ -79,20 +80,28 @@ fun CartScreen(navController: NavHostController) {
                 .background(WishBoardTheme.colors.white)
                 .padding(top = paddingValues.calculateTopPadding()),
         ) {
-            LazyColumn(
-                modifier = Modifier.weight(1f),
-            ) {
-                itemsIndexed(cartItems) { idx, item ->
-                    CartItem(
-                        cartItem = item,
-                        moveToDetail = { id -> navController.navigate("${MainScreen.WishItemDetail.route}/$id") },
-                        onChangeItemCount = { count -> /*TODO*/ },
-                        onClickDelete = { id -> isOpenDialog = true },
-                    )
-                    if (idx < cartItems.lastIndex) WishBoardDivider()
+            if (cartItems.isEmpty()) {
+                WishBoardEmptyView(
+                    modifier = Modifier
+                        .weight(1f)
+                        .align(Alignment.CenterHorizontally),
+                    guideTextRes = R.string.empty_cart_guide_text,
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    itemsIndexed(cartItems) { idx, item ->
+                        CartItem(
+                            cartItem = item,
+                            moveToDetail = { id -> navController.navigate("${MainScreen.WishItemDetail.route}/$id") },
+                            onChangeItemCount = { count -> /*TODO*/ },
+                            onClickDelete = { id -> isOpenDialog = true },
+                        )
+                        if (idx < cartItems.lastIndex) WishBoardDivider()
+                    }
                 }
             }
-
             CartTotalDisplay(totalCount = cartItems.size, totalPrice = cartItems.sumOf { it.price * it.count })
         }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
@@ -14,7 +14,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
-import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.hyeeyoung.wishboard.presentation.folder
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -11,7 +12,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
+import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
@@ -46,21 +49,28 @@ fun FolderDetailScreen(
                 ),
             )
         }) { paddingValues ->
-            LazyVerticalGrid(
-                modifier = Modifier
-                    .background(WishBoardTheme.colors.white)
-                    .padding(
-                        top = paddingValues.calculateTopPadding(),
-                    ),
-                columns = GridCells.Fixed(2),
-            ) {
-                items(wishList) { wishItem ->
-                    WishItem(
-                        wishItem = wishItem,
-                        onClickItem = {
-                            wishNavController.navigate("${MainScreen.WishItemDetail.route}/${wishItem.id}")
-                        },
-                    )
+            val contentModifier = Modifier
+                .fillMaxSize()
+                .background(WishBoardTheme.colors.white)
+                .padding(
+                    top = paddingValues.calculateTopPadding(),
+                )
+
+            if (wishList.isEmpty()) {
+                WishBoardEmptyView(modifier = contentModifier, guideTextRes = R.string.empty_wishlist_guide_text)
+            } else {
+                LazyVerticalGrid(
+                    modifier = contentModifier,
+                    columns = GridCells.Fixed(2),
+                ) {
+                    items(wishList) { wishItem ->
+                        WishItem(
+                            wishItem = wishItem,
+                            onClickItem = {
+                                wishNavController.navigate("${MainScreen.WishItemDetail.route}/${wishItem.id}")
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -31,6 +32,7 @@ import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
+import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.Folder
@@ -62,20 +64,27 @@ fun FolderScreen(navController: NavHostController) {
             },
         )
     }) { paddingValues ->
-        LazyVerticalGrid(
-            modifier = Modifier
-                .background(WishBoardTheme.colors.white)
-                .padding(top = paddingValues.calculateTopPadding(), start = 8.dp, end = 8.dp),
-            columns = GridCells.Fixed(2),
-        ) {
-            items(folders) { folder ->
-                FolderItem(
-                    folder = folder,
-                    onClickFolder = { folderId ->
-                        navController.navigate("${MainScreen.FolderDetail.route}/$folderId/${folder.name}")
-                    },
-                    onClickMore = { },
-                )
+        val contentModifier = Modifier
+            .fillMaxSize()
+            .background(WishBoardTheme.colors.white)
+            .padding(top = paddingValues.calculateTopPadding(), start = 8.dp, end = 8.dp)
+
+        if (folders.isEmpty()) {
+            WishBoardEmptyView(modifier = contentModifier, guideTextRes = R.string.empty_folder_guide_text)
+        } else {
+            LazyVerticalGrid(
+                modifier = contentModifier,
+                columns = GridCells.Fixed(2),
+            ) {
+                items(folders) { folder ->
+                    FolderItem(
+                        folder = folder,
+                        onClickFolder = { folderId ->
+                            navController.navigate("${MainScreen.FolderDetail.route}/$folderId/${folder.name}")
+                        },
+                        onClickMore = { },
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderScreen.kt
@@ -30,9 +30,9 @@ import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
-import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.Folder

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -30,6 +31,7 @@ import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.WishBoardSnackbarHost
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.component.showSnackbar
+import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Green500
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
@@ -63,28 +65,33 @@ fun NotiScreen(navController: NavHostController) {
         topBar = { WishBoardMainTopBar(titleRes = R.string.noti) },
         snackbarHost = { WishBoardSnackbarHost(hostState = snackbarHostState) },
     ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier
-                .background(WishBoardTheme.colors.white)
-                .padding(top = paddingValues.calculateTopPadding()),
-        ) {
-            itemsIndexed(notiList) { idx, item ->
-                NotiItem(
-                    noti = item,
-                    onClickNotiWithLink = { site ->
-                        navController.moveToWebView(
-                            title = site.getDomainName(),
-                            url = site,
-                        )
-                    },
-                    onClickNotiWithoutLink = {
-                        snackbarHostState.showSnackbar(
-                            snackbarMsgForNotiLink,
-                            coroutineScope,
-                        )
-                    },
-                )
-                if (idx < notiList.lastIndex) WishBoardDivider()
+        val contentModifier = Modifier
+            .fillMaxSize()
+            .background(WishBoardTheme.colors.white)
+            .padding(top = paddingValues.calculateTopPadding())
+
+        if (notiList.isEmpty()) {
+            WishBoardEmptyView(modifier = contentModifier, guideTextRes = R.string.empty_folder_guide_text)
+        } else {
+            LazyColumn(modifier = contentModifier) {
+                itemsIndexed(notiList) { idx, item ->
+                    NotiItem(
+                        noti = item,
+                        onClickNotiWithLink = { site ->
+                            navController.moveToWebView(
+                                title = site.getDomainName(),
+                                url = site,
+                            )
+                        },
+                        onClickNotiWithoutLink = {
+                            snackbarHostState.showSnackbar(
+                                snackbarMsgForNotiLink,
+                                coroutineScope,
+                            )
+                        },
+                    )
+                    if (idx < notiList.lastIndex) WishBoardDivider()
+                }
             }
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiScreen.kt
@@ -28,10 +28,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.WishBoardSnackbarHost
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.component.showSnackbar
-import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Green500
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -11,7 +12,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,13 +25,14 @@ import com.hyeeyoung.wishboard.config.navigation.screen.Calendar
 import com.hyeeyoung.wishboard.config.navigation.screen.Cart
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
+import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 import com.hyeeyoung.wishboard.domain.model.WishItem
 import com.hyeeyoung.wishboard.presentation.wish.component.WishItem
 
 @Composable
-fun WishlistScreen(modifier: Modifier = Modifier, navController: NavHostController) {
+fun WishlistScreen(navController: NavHostController) {
     val wishList = listOf(
         WishItem(
             1L,
@@ -76,19 +77,23 @@ fun WishlistScreen(modifier: Modifier = Modifier, navController: NavHostControll
             false,
         ),
     )
-    WishboardTheme { // TODO Theme 사용 여부 고려
-        Surface(modifier = modifier) {
-            Scaffold(topBar = {
-                WishlistTopBar(onClickCart = { navController.navigate(Cart.route) }, onClickCalendar = {
-                    navController.navigate(Calendar.route)
-                })
-            }) { paddingValues ->
+
+    WishboardTheme {
+        Scaffold(topBar = {
+            WishlistTopBar(onClickCart = { navController.navigate(Cart.route) }, onClickCalendar = {
+                navController.navigate(Calendar.route)
+            })
+        }) { paddingValues ->
+            val contentModifier = Modifier
+                .fillMaxSize()
+                .background(WishBoardTheme.colors.white)
+                .padding(top = paddingValues.calculateTopPadding())
+
+            if (wishList.isEmpty()) {
+                WishBoardEmptyView(modifier = contentModifier, guideTextRes = R.string.empty_wishlist_guide_text)
+            } else {
                 LazyVerticalGrid(
-                    modifier = Modifier
-                        .background(WishBoardTheme.colors.white)
-                        .padding(
-                            top = paddingValues.calculateTopPadding(),
-                        ),
+                    modifier = contentModifier,
                     columns = GridCells.Fixed(2),
                 ) {
                     items(wishList) { wishItem ->

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/WishIistScreen.kt
@@ -24,8 +24,8 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.config.navigation.screen.Calendar
 import com.hyeeyoung.wishboard.config.navigation.screen.Cart
 import com.hyeeyoung.wishboard.config.navigation.screen.MainScreen
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
-import com.hyeeyoung.wishboard.designsystem.component.text.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 import com.hyeeyoung.wishboard.domain.model.WishItem

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,7 +85,6 @@
     <!-- Noti -->
     <string name="noti">알림</string>
     <string name="noti_item_type">%s 알림</string>
-    <string name="noti_no_item_view">앗, 일정이 없어요!\n상품 일정을 지정하고 알림을 받아보세요!</string>
 
     <!-- Calendar -->
     <string name="calendar_schedule_title">%d월 %d일 일정</string>
@@ -148,5 +147,11 @@
     <string name="dialog_withdraw_title">회원 탈퇴</string>
     <string name="dialog_withdraw_description">정말 탈퇴하시겠습니까?\n탈퇴 시 앱 내 모든 데이터가 사라집니다.\n서비스를 탈퇴하시려면 이메일을 입력해 주세요.</string>
     <string name="dialog_withdraw_confirm_btn_text">탈퇴</string>
+
+    <!-- Empty -->
+    <string name="empty_wishlist_guide_text">앗, 아이템이 없어요!\n갖고 싶은 아이템을 등록해 보세요!</string>
+    <string name="empty_cart_guide_text">앗, 장바구니가 비어있어요!\n구매할 아이템을 장바구니에 담아보세요!</string>
+    <string name="empty_folder_guide_text">앗, 폴더가 없어요!\n폴더를 추가해서 아이템을 정리해 보세요!</string>
+    <string name="empty_noti_guide_text">앗, 일정이 없어요!\n상품 일정을 지정하고 알림을 받아보세요!</string>
 
 </resources>


### PR DESCRIPTION
## What is this PR? 🔍
- closed #39

## Key Changes 🔑
1. 공용 엠티뷰 구현 (아이콘 + 텍스트 구성)
   <img width="300" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/34848f3e-c99e-407d-b61b-adb277ccb9f4">

3. 홈, 폴더, 알림, 장바구니 화면에서 엠티뷰 추가
4. 캘린더 스케줄 엠티뷰를 공용 엠티뷰로 변경

|홈 엠티뷰|
|---|
|<img width="183" alt="스크린샷 2023-09-11 오후 8 47 16" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/469aa3af-3a7d-4ea7-8957-0f0fd1ff9292">|

