### PR TITLE
모달 UI 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,8 @@ dependencies {
     implementation(libs.bundles.androidx)
     implementation(composeBom)
     implementation(libs.bundles.compose)
+    implementation(libs.compose.material.three)
+
     implementation(libs.bundles.dagger.hilt)
     kapt(libs.bundles.compiler)
     implementation(platform(libs.firebase.bom))

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/Picker.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/Picker.kt
@@ -1,0 +1,138 @@
+package com.hyeeyoung.wishboard.designsystem.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.util.extension.pxToDp
+import com.hyeeyoung.wishboard.presentation.util.type.NotiType
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import timber.log.Timber
+
+private const val EMPTY = " "
+private const val VISIBLE_ITEM_COUNT = 3
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun Picker(
+    modifier: Modifier = Modifier,
+    itemList: List<String>,
+    selectedItem: MutableState<String>,
+    visibleItemsCount: Int = VISIBLE_ITEM_COUNT,
+    startIdx: Int = 0,
+    textModifier: Modifier = Modifier,
+    mainTextStyle: TextStyle = WishBoardTheme.typography.suitB3,
+    subTextStyle: TextStyle = WishBoardTheme.typography.suitD2,
+    enableInfiniteScroll: Boolean = true,
+) {
+    if (visibleItemsCount < 2) throw IllegalArgumentException("Picker를 사용하기에 적합하지 않음")
+    val items =
+        if (!enableInfiniteScroll && itemList.size < VISIBLE_ITEM_COUNT) {
+            listOf(EMPTY) + itemList.plus(EMPTY)
+        } else {
+            itemList
+        }
+
+    val visibleItemsHalf = visibleItemsCount / 2
+    val listScrollCount = if (enableInfiniteScroll) Integer.MAX_VALUE else items.size
+    val listFirstItemIdx = if (enableInfiniteScroll) {
+        val listScrollHalf = listScrollCount / 2
+        listScrollHalf - listScrollHalf % items.size - visibleItemsHalf + startIdx
+    } else {
+        startIdx
+    }
+
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = listFirstItemIdx)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+    var itemHeightPx by remember { mutableStateOf(0) }
+    val itemHeightDp = itemHeightPx.pxToDp()
+
+    val fadingEdgeGradient = remember {
+        Brush.verticalGradient(
+            0f to Color.Transparent,
+            0.5f to Color.Black,
+            1f to Color.Transparent,
+        )
+    }
+
+    fun getItem(index: Int) = items[index % items.size]
+
+    LaunchedEffect(listState) {
+        snapshotFlow {
+            Timber.e(listState.firstVisibleItemIndex.toString())
+            listState.firstVisibleItemIndex
+        }.map { index -> getItem(index + visibleItemsHalf) }
+            .distinctUntilChanged()
+            .collect { item -> selectedItem.value = item }
+    }
+
+    Box(modifier = modifier) {
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(itemHeightDp * visibleItemsCount)
+                .fadingEdge(fadingEdgeGradient),
+        ) {
+            items(listScrollCount) { idx ->
+                val isSelected = getItem(idx) == selectedItem.value
+
+                Text(
+                    text = getItem(idx),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = if (isSelected) mainTextStyle else subTextStyle,
+                    color = WishBoardTheme.colors.gray700,
+                    modifier = textModifier
+                        .onSizeChanged { size ->
+                            itemHeightPx = size.height
+                        }
+                        .padding(vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+private fun Modifier.fadingEdge(brush: Brush) = this
+    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+    .drawWithContent {
+        drawContent()
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }
+
+@Preview(showSystemUi = true)
+@Composable
+fun PreviewPicker() {
+    Picker(itemList = NotiType.values().map { it.str }, startIdx = 2, selectedItem = remember { mutableStateOf("") })
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardModal.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardModal.kt
@@ -1,0 +1,95 @@
+package com.hyeeyoung.wishboard.designsystem.component.dialog
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.noti.NotiModalContent
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WishBoardModal(
+    isOpen: Boolean,
+    @StringRes titleRes: Int,
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+
+    if (!isOpen) return
+    ModalBottomSheet(
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        onDismissRequest = { onDismissRequest() },
+        sheetState = sheetState,
+        containerColor = WishBoardTheme.colors.white,
+        dragHandle = null,
+    ) {
+        Box(
+            modifier = Modifier
+                .heightIn(max = 317.dp)
+                .fillMaxWidth(),
+        ) {
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 5.dp, end = 8.dp),
+            ) {
+                WishBoardIconButton(
+                    modifier = Modifier.background(WishBoardTheme.colors.white),
+                    iconRes = R.drawable.ic_close,
+                    onClick = {
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            if (!sheetState.isVisible) {
+                                onDismissRequest()
+                            }
+                        }
+                    },
+                )
+            }
+
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .align(Alignment.CenterHorizontally),
+                    text = stringResource(titleRes),
+                    style = WishBoardTheme.typography.suitH3,
+                    color = WishBoardTheme.colors.gray700,
+                )
+                content()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewWishBoardModal() {
+    WishBoardModal(
+        isOpen = true,
+        titleRes = R.string.wish_item_link_sharing_upload_noti_setting,
+        onDismissRequest = {},
+        content = { NotiModalContent() },
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardTwoOptionModal.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardTwoOptionModal.kt
@@ -1,0 +1,124 @@
+package com.hyeeyoung.wishboard.designsystem.component.dialog
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WishBoardTwoOptionModal(
+    isOpen: Boolean,
+    @StringRes topOption: Int,
+    @StringRes bottomOption: Int,
+    onClickTop: () -> Unit = {},
+    onClickBottom: () -> Unit = {},
+    onDismissRequest: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+
+    if (!isOpen) return
+    ModalBottomSheet(
+        onDismissRequest = { onDismissRequest() },
+        sheetState = sheetState,
+        containerColor = Color.Transparent,
+        dragHandle = null,
+    ) {
+        Column(
+            modifier = Modifier
+                .navigationBarsPadding()
+                .padding(horizontal = 8.dp),
+        ) {
+            Column(
+                modifier = Modifier.background(
+                    color = WishBoardTheme.colors.white,
+                    shape = RoundedCornerShape(16.dp),
+                ),
+            ) {
+                Text(
+                    modifier = Modifier
+                        .noRippleClickable {
+                            onClickTop()
+                            onDismissRequest()
+                        }
+                        .padding(vertical = 16.dp)
+                        .fillMaxWidth(),
+                    text = stringResource(topOption),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = WishBoardTheme.colors.gray600,
+                    textAlign = TextAlign.Center,
+                )
+                WishBoardDivider()
+                Text(
+                    modifier = Modifier
+                        .noRippleClickable {
+                            onClickBottom()
+                            onDismissRequest()
+                        }
+                        .padding(vertical = 16.dp)
+                        .fillMaxWidth(),
+                    text = stringResource(bottomOption),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = WishBoardTheme.colors.pink700,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(modifier = Modifier.size(4.dp))
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .noRippleClickable {
+                        scope
+                            .launch { sheetState.hide() }
+                            .invokeOnCompletion {
+                                if (!sheetState.isVisible) {
+                                    onDismissRequest()
+                                }
+                            }
+                    }
+                    .background(color = WishBoardTheme.colors.white, shape = RoundedCornerShape(16.dp))
+                    .padding(vertical = 16.dp),
+                text = stringResource(R.string.cancel),
+                style = WishBoardTheme.typography.suitB3,
+                color = WishBoardTheme.colors.gray600,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewWishBoardTwoOptionModal() {
+    WishBoardTwoOptionModal(
+        isOpen = true,
+        topOption = R.string.modal_folder_name_edit_title,
+        bottomOption = R.string.dialog_folder_delete_title,
+        onDismissRequest = {},
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/textfield/WishBoardTextField.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/textfield/WishBoardTextField.kt
@@ -37,7 +37,7 @@ fun WishBoardTextField(
     label: String? = null,
     errorMsg: String? = null,
     placeholder: String,
-    onTextChange: (String) -> Unit,
+    onTextChange: (String) -> Unit = {},
     isError: Boolean = false,
     singleLine: Boolean = true,
     maxLength: Int? = null,
@@ -142,7 +142,6 @@ fun PreviewWishBoardTextField() {
         modifier = Modifier.fillMaxWidth(),
         input = input,
         placeholder = stringResource(id = R.string.sign_email_placeholder),
-        onTextChange = {},
         label = stringResource(id = R.string.sign_email),
     )
 }
@@ -155,7 +154,6 @@ fun PreviewWishBoardTextFieldWithTimer() {
         modifier = Modifier.fillMaxWidth(),
         input = input,
         placeholder = stringResource(id = R.string.sign_in_verification_code_placeholder),
-        onTextChange = {},
         endComponent = WishBoardTextFieldComponent.Timer(4, 56),
     )
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -150,6 +150,7 @@ fun CartItem(
 
                 Surface(modifier = Modifier.padding(top = 6.dp, end = 4.dp)) {
                     WishBoardIconButton(
+                        modifier = Modifier.background(WishBoardTheme.colors.white),
                         iconRes = R.drawable.ic_delete_small_gray,
                         onClick = { onClickDelete(cartItem.id) },
                     )

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderListModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderListModalContent.kt
@@ -1,0 +1,115 @@
+package com.hyeeyoung.wishboard.presentation.folder
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
+import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
+import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.model.Folder
+import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
+
+@Composable
+fun FolderListModalContent(selectedFolderId: Long?) {
+    val folder = Folder(
+        id = 1L,
+        name = "아우터",
+        thumbnail = "https://url.kr/8vwf1e",
+        itemCount = 1,
+    )
+//    val folders = List(8) { folder.copy(id = it.toLong()) } // TODO 서버 연동 후 삭제
+    val folders = emptyList<Folder>()
+    var selectedId by remember { mutableStateOf(selectedFolderId) }
+
+    if (folders.isEmpty()) {
+        WishBoardEmptyView(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(WishBoardTheme.colors.white),
+            guideTextRes = R.string.empty_folder_guide_text,
+        )
+    } else {
+        LazyColumn(
+            modifier = Modifier
+                .padding(top = 5.dp)
+                .background(WishBoardTheme.colors.white),
+            contentPadding = PaddingValues(bottom = 64.dp),
+        ) {
+            itemsIndexed(folders) { idx, folder ->
+                HorizontalFolderItem(
+                    folder = folder,
+                    isSelected = selectedId == folder.id,
+                    onClickFolder = { folderId -> selectedId = folderId },
+                )
+                if (idx != folders.lastIndex) {
+                    WishBoardDivider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HorizontalFolderItem(folder: Folder, isSelected: Boolean, onClickFolder: (Long) -> Unit) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .noRippleClickable { onClickFolder(folder.id) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ColoredImage(
+            model = folder.thumbnail,
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape),
+        )
+
+        Text(
+            modifier = Modifier
+                .padding(start = 10.dp)
+                .weight(1f),
+            text = folder.name,
+            style = WishBoardTheme.typography.suitD2,
+            color = WishBoardTheme.colors.gray700,
+        )
+
+        if (isSelected) {
+            Spacer(modifier = Modifier.size(10.dp))
+            Icon(
+                modifier = Modifier
+                    .size(24.dp),
+                painter = painterResource(id = R.drawable.ic_check_white),
+                contentDescription = null,
+                tint = WishBoardTheme.colors.green500,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun PreviewFolderListModalContent() {
+    FolderListModalContent(1L)
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderUploadModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderUploadModalContent.kt
@@ -1,0 +1,49 @@
+package com.hyeeyoung.wishboard.presentation.folder
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
+
+@Composable
+fun FolderUploadModalContent(folder: Pair<Long, String>? = null) {
+    val nameInput = remember { mutableStateOf(folder?.second ?: "") }
+
+    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp)) {
+        Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            WishBoardTextField(
+                input = nameInput,
+                placeholder = stringResource(id = R.string.modal_folder_upload_placeholder),
+                errorMsg = stringResource(id = R.string.modal_folder_upload_error),
+            )
+        }
+
+        WishBoardWideButton(
+            enabled = true,
+            onClick = { /*TODO*/ },
+            text = stringResource(id = if (folder == null) R.string.add else R.string.modal_folder_name_edit_btn_text),
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PreviewNewFolderModalContent() {
+    FolderUploadModalContent()
+}
+
+@Composable
+@Preview
+fun PreviewFolderEditModalContent() {
+    FolderUploadModalContent(Pair(1L, "셀린느"))
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/ProfileEditScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/ProfileEditScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,6 +25,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardTwoOptionModal
 import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
@@ -32,6 +35,8 @@ import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 
 @Composable
 fun ProfileEditScreen(navController: NavHostController) {
+    var isOpenModal by remember { mutableStateOf(false) }
+
     WishboardTheme {
         Scaffold(topBar = {
             WishBoardTopBar(
@@ -58,7 +63,10 @@ fun ProfileEditScreen(navController: NavHostController) {
                     Icon(
                         modifier = Modifier
                             .size(imageSize.dp)
-                            .align(Alignment.Center),
+                            .align(Alignment.Center)
+                            .noRippleClickable {
+                                isOpenModal = true
+                            },
                         painter = painterResource(id = R.drawable.ic_placeholder_user_profile),
                         contentDescription = null,
                         tint = Color.Unspecified,
@@ -89,6 +97,13 @@ fun ProfileEditScreen(navController: NavHostController) {
                     text = stringResource(id = R.string.complete),
                 )
             }
+
+            WishBoardTwoOptionModal(
+                isOpen = isOpenModal,
+                topOption = R.string.modal_image_upload_camera,
+                bottomOption = R.string.modal_image_upload_gallery,
+                onDismissRequest = { isOpenModal = false },
+            )
         }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiModalContent.kt
@@ -1,0 +1,102 @@
+package com.hyeeyoung.wishboard.presentation.noti
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.Picker
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.style.Gray100
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.util.type.NotiType
+import kotlinx.datetime.LocalDateTime
+
+private val notiType = NotiType.values().map { it.str }
+
+@Composable
+fun NotiModalContent(type: NotiType? = null, date: LocalDateTime? = null) {
+    val selectedType = remember { mutableStateOf("") }
+    val selectedDate = remember { mutableStateOf("") }
+    val selectedHour = remember { mutableStateOf("") }
+    val selectedMinute = remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp)) {
+        Box(modifier = Modifier.weight(1f)) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.Center)
+                    .height(34.dp),
+                onDraw = { drawRoundRect(color = Gray100, cornerRadius = CornerRadius(6.dp.toPx())) },
+            )
+            Picker(
+                modifier = Modifier
+                    .padding(start = 16.dp)
+                    .align(Alignment.CenterStart)
+                    .widthIn(max = 80.dp),
+                itemList = notiType,
+                startIdx = type?.ordinal ?: 0,
+                selectedItem = selectedType,
+            )
+            Picker(
+                modifier = Modifier
+                    .widthIn(max = 126.dp)
+                    .align(Alignment.Center),
+                itemList = listOf("22년 2월 19일 토", "22년 12월 19일 토", "22년 10월 19일 토"), // TODO 실데이터 넣기
+                selectedItem = selectedDate,
+            )
+            Row(modifier = Modifier.align(Alignment.CenterEnd)) {
+                Picker(
+                    modifier = Modifier.widthIn(max = 40.dp),
+                    itemList = listOf("1", "2", "3", "10", "12"),
+                    selectedItem = selectedHour,
+                )
+                Text(
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically),
+                    text = stringResource(id = R.string.modal_noti_setting_time_delimiter),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = WishBoardTheme.colors.gray700,
+                )
+                Picker(
+                    modifier = Modifier
+                        .padding(end = 6.dp)
+                        .widthIn(max = 40.dp),
+                    itemList = listOf("00", "30"),
+                    selectedItem = selectedMinute,
+                    enableInfiniteScroll = false,
+                )
+            }
+        }
+        Text(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(bottom = 6.dp),
+            text = stringResource(id = R.string.modal_noti_setting_guide),
+            style = WishBoardTheme.typography.suitD3,
+            color = WishBoardTheme.colors.gray300,
+        )
+        WishBoardWideButton(enabled = true, onClick = { /*TODO*/ }, text = stringResource(id = R.string.complete))
+    }
+}
+
+@Composable
+@Preview(showSystemUi = true)
+fun PreviewNotiModalContent() {
+    NotiModalContent()
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/LinkSharingWishUploadScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/LinkSharingWishUploadScreen.kt
@@ -41,12 +41,17 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardModal
 import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardMiniSingleTextField
 import com.hyeeyoung.wishboard.designsystem.style.MontserratFamily
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 import com.hyeeyoung.wishboard.designsystem.util.PriceTransformation
+import com.hyeeyoung.wishboard.presentation.folder.FolderUploadModalContent
 import com.hyeeyoung.wishboard.presentation.model.FolderSummary
+import com.hyeeyoung.wishboard.presentation.noti.NotiModalContent
+import com.hyeeyoung.wishboard.presentation.upload.model.ModalInfo
+import com.hyeeyoung.wishboard.presentation.upload.model.ModalRoute
 import com.hyeeyoung.wishboard.presentation.util.extension.isEmptyOrBlank
 import com.hyeeyoung.wishboard.presentation.util.extension.makeValidPriceStr
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
@@ -58,6 +63,8 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
     val nameInput = remember { mutableStateOf("") }
     val priceInput = remember { mutableStateOf("") }
     val image = "https://url.kr/8vwf1e" // TODO 서버 연동 필요
+
+    var modalInfo by remember { mutableStateOf(ModalInfo(false)) }
 
     WishboardTheme {
         Column(
@@ -118,7 +125,7 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
 
                     Row(
                         modifier = Modifier
-                            .noRippleClickable { /*TODO*/ }
+                            .noRippleClickable { modalInfo = ModalInfo(true, ModalRoute.NOTI) }
                             .padding(8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -164,7 +171,7 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
                         item {
-                            NewFolder()
+                            NewFolder(onClickNew = { modalInfo = ModalInfo(true, ModalRoute.FOLDER) })
                         }
                         items(folders) {
                             FolderItem(
@@ -215,6 +222,17 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
                 }
             }
         }
+
+        WishBoardModal(
+            isOpen = modalInfo.isOpen,
+            titleRes = modalInfo.modalRoute?.titleRes ?: R.string.modal_folder_selection_title,
+            onDismissRequest = { modalInfo = ModalInfo(false) },
+        ) {
+            when (modalInfo.modalRoute) {
+                ModalRoute.FOLDER -> FolderUploadModalContent()
+                else -> NotiModalContent()
+            }
+        }
     }
 }
 
@@ -260,11 +278,11 @@ fun FolderItem(
 }
 
 @Composable
-fun NewFolder() {
+fun NewFolder(onClickNew: () -> Unit) {
     Column(
         modifier = Modifier
             .size(IMAGE_SIZE.dp)
-            .noRippleClickable { /*TODO*/ }
+            .noRippleClickable { onClickNew() }
             .border(width = 1.dp, color = WishBoardTheme.colors.gray100, shape = RoundedCornerShape(10.dp)),
         verticalArrangement = Arrangement.Bottom,
     ) {

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/component/ShopLinkModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/component/ShopLinkModalContent.kt
@@ -1,0 +1,42 @@
+package com.hyeeyoung.wishboard.presentation.upload.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
+import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
+
+@Composable
+fun ShopLinkModalContent(link: String? = null, onClickBtn: () -> Unit = {}) {
+    val linkInput = remember { mutableStateOf(link ?: "") }
+    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp)) {
+        Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            WishBoardTextField(
+                input = linkInput,
+                placeholder = stringResource(id = R.string.modal_shop_link_placeholder),
+                errorMsg = stringResource(id = R.string.modal_shop_link_error),
+            )
+        }
+
+        WishBoardWideButton(
+            enabled = true,
+            onClick = { onClickBtn() },
+            text = stringResource(id = R.string.modal_shop_link_item_load_btn_text),
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PreviewShopLinkModalContent() {
+    ShopLinkModalContent()
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/model/ModalInfo.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/model/ModalInfo.kt
@@ -1,0 +1,6 @@
+package com.hyeeyoung.wishboard.presentation.upload.model
+
+data class ModalInfo(
+    val isOpen: Boolean,
+    val modalRoute: ModalRoute? = null,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/model/ModalRoute.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/model/ModalRoute.kt
@@ -1,0 +1,10 @@
+package com.hyeeyoung.wishboard.presentation.upload.model
+
+import androidx.annotation.StringRes
+import com.hyeeyoung.wishboard.R
+
+enum class ModalRoute(@StringRes val titleRes: Int) {
+    FOLDER(R.string.modal_folder_selection_title), NOTI(R.string.modal_noti_setting_title), SHOP(
+        R.string.modal_shop_link_title,
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/extension/IntExt.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/extension/IntExt.kt
@@ -1,7 +1,12 @@
 package com.hyeeyoung.wishboard.presentation.util.extension
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
 import java.text.NumberFormat
 import java.util.Locale
 
 fun Int?.setPriceFormat(): String =
     NumberFormat.getNumberInstance(Locale.US).format(this ?: 0)
+
+@Composable
+fun Int.pxToDp() = with(LocalDensity.current) { this@pxToDp.toDp() }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="edit">편집</string>
     <string name="later">나중에</string>
     <string name="complete">완료</string>
+    <string name="add">추가</string>
     <string name="cancel">취소</string>
     <string name="delete">삭제</string>
 
@@ -153,5 +154,26 @@
     <string name="empty_cart_guide_text">앗, 장바구니가 비어있어요!\n구매할 아이템을 장바구니에 담아보세요!</string>
     <string name="empty_folder_guide_text">앗, 폴더가 없어요!\n폴더를 추가해서 아이템을 정리해 보세요!</string>
     <string name="empty_noti_guide_text">앗, 일정이 없어요!\n상품 일정을 지정하고 알림을 받아보세요!</string>
+
+    <!-- Modal -->
+    <string name="modal_folder_selection_title">폴더 선택</string>
+
+    <string name="modal_noti_setting_title">상품 알림 설정</string>
+    <string name="modal_noti_setting_guide">30분 전에 일정을 알려드려요. 시간은 30분 단위로 설정 가능해요!</string>
+    <string name="modal_noti_setting_time_delimiter">:</string>
+
+    <string name="modal_shop_link_title">쇼핑몰 링크로 아이템 불러오기</string>
+    <string name="modal_shop_link_item_load_btn_text">아이템 불러오기</string>
+    <string name="modal_shop_link_placeholder">쇼핑몰 링크를 입력해 주세요.</string>
+    <string name="modal_shop_link_error">쇼핑몰 링크를 다시 확인해 주세요.</string>
+
+    <string name="modal_new_folder_title">새 폴더 추가</string>
+    <string name="modal_folder_name_edit_title">폴더명 수정</string>
+    <string name="modal_folder_name_edit_btn_text">수정</string>
+    <string name="modal_folder_upload_placeholder">폴더명을 입력해 주세요.</string>
+    <string name="modal_folder_upload_error">동일 이름의 폴더가 있어요!</string>
+
+    <string name="modal_image_upload_camera">사진 촬영</string>
+    <string name="modal_image_upload_gallery">사진 선택</string>
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ junit = "4.13.2"
 
 compose-compiler = "1.4.4"
 compose-bom = "2023.05.01"
+material = "1.1.1"
 compose-navigation = "2.5.3"
 compose-constraintlayout = "1.0.1"
 compose-coil = "2.4.0"
@@ -53,7 +54,7 @@ compose-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel
 compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "compose-navigation"}
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
-compose-material-three = { module = "androidx.compose.material3:material3" }
+compose-material-three = { module = "androidx.compose.material3:material3", version.ref = "material" }
 compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "compose-constraintlayout" }
 compose-coil = { module = "io.coil-kt:coil-compose", version.ref = "compose-coil" }
 compose-test-junit = { module = "androidx.compose.ui:ui-test-junit4" }
@@ -88,7 +89,7 @@ firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlyti
 
 [bundles]
 androidx = ["core-ktx", "lifecycle", "appcompat", "security"]
-compose = ["compose-activity", "compose-runtime-livedata", "compose-lifecycle-viewmodel", "compose-navigation", "compose-ui", "compose-ui-tooling-preview", "compose-material-three", "compose-constraintlayout", "compose-coil", "compose-lottie"]
+compose = ["compose-activity", "compose-runtime-livedata", "compose-lifecycle-viewmodel", "compose-navigation", "compose-ui", "compose-ui-tooling-preview", "compose-constraintlayout", "compose-coil", "compose-lottie"]
 dagger-hilt = ["hilt"]
 firebase = ["firebase-messeging", "firebase-analytics", "firebase-crashlytics"]
 network = ["okhttp", "okhttp-logging-interceptor", "retrofit", "kotlinx-serialization-json", "kotlinx-serialization-converter"]


### PR DESCRIPTION
## What is this PR? 🔍
- closed #41

## Key Changes 🔑
1. 공용 모달 구현
   - 상단에 라운딩이 적용된 기본 모달 구현
   - 수직방향으로 옵션 두개를 나란히 배치한 모달 구현

2. 모달 컨텐츠 UI 구현
   - 알림 설정
   - 쇼핑몰 링크로 아이템 불러오기
   - 폴더 선택, 업로드, 삭제, 폴더명 수정 및 삭제 선택
   - 사진 찍기 및 선택

3. 각 화면 별 모달 띄우기
   - 한 화면에서 하나의 모달 컴포저블을 추가하고 해당 컴포저블에서 모달 콘텐츠만 교체하는 방식으로 구현


|기본 모달|옵션 모달|
|---|---|
|<img width="231" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/01dc8922-56c0-48a9-81b7-5243c82c034d">|<img width="232" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/021061ba-f6f0-46e3-be84-554c6c527264">|
