### PR TITLE
회원탈퇴 다이얼로그에 텍스트 필드 추가

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ripple.rememberRipple
@@ -36,6 +38,7 @@ fun WishBoardDialog(
     isWarningDialog: Boolean = true,
     onClickConfirm: () -> Unit,
     onDismissRequest: () -> Unit,
+    content: (@Composable () -> Unit)? = null,
 ) {
     if (!isOpen) return
     Dialog(onDismissRequest = { onDismissRequest() }) {
@@ -52,12 +55,18 @@ fun WishBoardDialog(
                 color = WishBoardTheme.colors.gray600,
             )
             Text(
-                modifier = Modifier.padding(top = 8.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
+                modifier = Modifier.padding(top = 8.dp, bottom = 0.dp, start = 16.dp, end = 16.dp),
                 text = stringResource(textRes.descriptionRes),
                 style = WishBoardTheme.typography.suitD2M,
                 color = WishBoardTheme.colors.gray300,
                 textAlign = TextAlign.Center,
             )
+
+            if (content == null) {
+                Spacer(modifier = Modifier.size(32.dp))
+            } else {
+                content()
+            }
 
             WishBoardDivider()
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -146,6 +147,8 @@ fun CartItem(
                     text = cartItem.name,
                     style = WishBoardTheme.typography.suitD2M,
                     color = WishBoardTheme.colors.gray700,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
 
                 Surface(modifier = Modifier.padding(top = 6.dp, end = 4.dp)) {

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyScreen.kt
@@ -37,6 +37,7 @@ import com.hyeeyoung.wishboard.designsystem.component.WishBoardToggleButton
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardMiniButton
 import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardThickDivider
+import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
@@ -135,6 +136,8 @@ fun MyScreen(navController: NavHostController) {
             item { Spacer(modifier = Modifier.size(64.dp)) }
         }
 
+        val emailInput = remember { mutableStateOf("") }
+
         dialogType?.let { type ->
             WishBoardDialog(
                 isOpen = true,
@@ -142,6 +145,22 @@ fun MyScreen(navController: NavHostController) {
                 isWarningDialog = type.isWaringDialog,
                 onClickConfirm = {},
                 onDismissRequest = { dialogType = null },
+                content =
+                if (type == DialogType.WITHDRAW) {
+                    {
+                        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 14.dp)) {
+                            WishBoardTextField(
+                                input = emailInput,
+                                placeholder = stringResource(id = R.string.sign_email_placeholder),
+                                errorMsg = stringResource(
+                                    id = R.string.dialog_withdraw_email_error,
+                                ),
+                            )
+                        }
+                    }
+                } else {
+                    null
+                },
             )
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -140,6 +141,8 @@ fun NotiItem(noti: Noti, onClickNotiWithLink: (String) -> Unit = {}, onClickNoti
                 text = noti.itemName,
                 style = WishBoardTheme.typography.suitD3M,
                 color = WishBoardTheme.colors.gray700,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             Text(
                 text = noti.date.toString(), // TODO 시간 포맷 적용

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wish/component/WishItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
@@ -54,7 +55,13 @@ fun WishItem(modifier: Modifier = Modifier, wishItem: WishItem, onClickItem: () 
                 .fillMaxWidth()
                 .padding(start = 10.dp, end = 10.dp, top = 10.dp, bottom = 20.dp),
         ) {
-            Text(text = wishItem.name, style = WishBoardTheme.typography.suitD3, color = WishBoardTheme.colors.gray700)
+            Text(
+                text = wishItem.name,
+                style = WishBoardTheme.typography.suitD3,
+                color = WishBoardTheme.colors.gray700,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
             Spacer(modifier = Modifier.size(8.dp))
             PriceText(
                 price = wishItem.price,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="dialog_withdraw_title">회원 탈퇴</string>
     <string name="dialog_withdraw_description">정말 탈퇴하시겠습니까?\n탈퇴 시 앱 내 모든 데이터가 사라집니다.\n서비스를 탈퇴하시려면 이메일을 입력해 주세요.</string>
     <string name="dialog_withdraw_confirm_btn_text">탈퇴</string>
+    <string name="dialog_withdraw_email_error">이메일을 다시 확인해 주세요.</string>
 
     <!-- Empty -->
     <string name="empty_wishlist_guide_text">앗, 아이템이 없어요!\n갖고 싶은 아이템을 등록해 보세요!</string>


### PR DESCRIPTION
## What is this PR? 🔍
- closed #45

## Key Changes 🔑
1. 회원탈퇴 다이얼로그에 텍스트 필드 추가
   - 기본 다이얼로그에 description과 버튼 사이에 content를 넣을 수 있도록 content 컴포저블 추가.
