### PR TITLE
ModalBottomSheet -> Activity화

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             android:name=".presentation.upload.LinkSharingWishUploadActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.WishLinkSharing"
+            android:theme="@style/Theme.Modal"
             android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity">
             <intent-filter>
@@ -44,6 +44,12 @@
                 <data android:mimeType="image/*" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".presentation.dialog.ModalActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Modal"
+            android:windowSoftInputMode="adjustResize"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/bottombar/WishBoardBottomBar.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/bottombar/WishBoardBottomBar.kt
@@ -56,10 +56,10 @@ fun WishBoardBottomBar(navController: NavHostController = rememberNavController(
                         navItem = navItem,
                         isSelected = isSelectedMenu(currentRoute = currentRoute, navItem = navItem),
                         onSelect = {
-                            if (navItem.Screen.route == BottomNavItem.Add.Screen.route) {
+                            if (navItem.screen.route == BottomNavItem.Add.screen.route) {
                                 onClickAdd()
                             } else {
-                                navController.navigate(route = navItem.Screen.route) {
+                                navController.navigate(route = navItem.screen.route) {
                                     popUpTo(navController.graph.findStartDestination().id) {
                                         saveState = true
                                     }
@@ -78,10 +78,10 @@ fun WishBoardBottomBar(navController: NavHostController = rememberNavController(
 fun isSelectedMenu(currentRoute: String?, navItem: BottomNavItem): Boolean {
     return when (navItem) {
         BottomNavItem.Folder ->
-            currentRoute in listOf(navItem.Screen.getStartRouteForMainTab(), MainScreen.FolderDetail.routeWithArg)
+            currentRoute in listOf(MainScreen.Folder.getStartRouteForMainTab(), MainScreen.FolderDetail.routeWithArg)
 
         else ->
-            currentRoute == navItem.Screen.getStartRouteForMainTab()
+            currentRoute == navItem.screen.getStartRouteForMainTab()
     }
 }
 
@@ -89,7 +89,7 @@ fun isSelectedMenu(currentRoute: String?, navItem: BottomNavItem): Boolean {
 fun BottomBarIconButton(navItem: BottomNavItem, isSelected: Boolean, onSelect: (String) -> Unit) = Column(
     modifier = Modifier
         .fillMaxHeight()
-        .noRippleClickable { onSelect(navItem.Screen.route) },
+        .noRippleClickable { onSelect(navItem.screen.route) },
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
 ) {
@@ -102,7 +102,7 @@ fun BottomBarIconButton(navItem: BottomNavItem, isSelected: Boolean, onSelect: (
 enum class BottomNavItem(
     @StringRes val label: Int,
     @DrawableRes val icon: Int,
-    val Screen: MainScreen,
+    val screen: MainScreen,
 ) {
     WishList(R.string.nav_menu_label_wishlist, R.drawable.ic_nav_wish_list, MainScreen.Wishlist),
     Folder(R.string.nav_menu_label_folder, R.drawable.ic_nav_folder, MainScreen.Folder),

--- a/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/designsystem/component/dialog/WishBoardDialog.kt
@@ -26,21 +26,18 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
-import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
+import com.hyeeyoung.wishboard.presentation.dialog.DialogData
 
 @Composable
 fun WishBoardDialog(
-    isOpen: Boolean,
-    textRes: WishBoardDialogTextRes,
-    isWarningDialog: Boolean = true,
+    dialogData: DialogData?,
     onClickConfirm: () -> Unit,
     onDismissRequest: () -> Unit,
     content: (@Composable () -> Unit)? = null,
 ) {
-    if (!isOpen) return
+    if (dialogData == null) return
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Column(
             modifier = Modifier
@@ -50,13 +47,13 @@ fun WishBoardDialog(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = stringResource(textRes.titleRes),
+                text = stringResource(dialogData.dialogTextRes.titleRes),
                 style = WishBoardTheme.typography.suitH3,
                 color = WishBoardTheme.colors.gray600,
             )
             Text(
                 modifier = Modifier.padding(top = 8.dp, bottom = 0.dp, start = 16.dp, end = 16.dp),
-                text = stringResource(textRes.descriptionRes),
+                text = stringResource(dialogData.dialogTextRes.descriptionRes),
                 style = WishBoardTheme.typography.suitD2M,
                 color = WishBoardTheme.colors.gray300,
                 textAlign = TextAlign.Center,
@@ -79,7 +76,7 @@ fun WishBoardDialog(
                         ) { onDismissRequest() }
                         .weight(1f)
                         .padding(vertical = 16.dp),
-                    text = stringResource(id = textRes.dismissBtnTextRes),
+                    text = stringResource(id = dialogData.dialogTextRes.dismissBtnTextRes),
                     style = WishBoardTheme.typography.suitB3,
                     color = WishBoardTheme.colors.gray600,
                     textAlign = TextAlign.Center,
@@ -103,9 +100,14 @@ fun WishBoardDialog(
                         }
                         .weight(1f)
                         .padding(vertical = 16.dp),
-                    text = stringResource(id = textRes.confirmBtnTextRes),
+                    text = stringResource(id = dialogData.dialogTextRes.confirmBtnTextRes),
                     style = WishBoardTheme.typography.suitB3,
-                    color = if (isWarningDialog) WishBoardTheme.colors.pink700 else WishBoardTheme.colors.green700,
+                    color =
+                    if (dialogData.isWarningDialog) {
+                        WishBoardTheme.colors.pink700
+                    } else {
+                        WishBoardTheme.colors.green700
+                    },
                     textAlign = TextAlign.Center,
                 )
             }
@@ -117,13 +119,7 @@ fun WishBoardDialog(
 @Composable
 fun PreviewWishBoardDialog() {
     WishBoardDialog(
-        isOpen = true,
-        textRes = WishBoardDialogTextRes(
-            titleRes = R.string.dialog_noti_title,
-            descriptionRes = R.string.dialog_noti_description,
-            dismissBtnTextRes = R.string.later,
-            confirmBtnTextRes = R.string.dialog_noti_confirm_btn_text,
-        ),
+        dialogData = DialogData.WishItemDelete(1L),
         onClickConfirm = {},
         onDismissRequest = {},
     )

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/cart/CartScreen.kt
@@ -42,8 +42,8 @@ import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardTopBar
 import com.hyeeyoung.wishboard.designsystem.style.Green500
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.dialog.DialogData
 import com.hyeeyoung.wishboard.presentation.model.CartItem
-import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
 import com.hyeeyoung.wishboard.presentation.model.WishBoardTopBarModel
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 import com.hyeeyoung.wishboard.presentation.wish.component.PriceText
@@ -61,9 +61,10 @@ fun CartScreen(navController: NavHostController) {
         ),
     )
     val cartItems = List(7) { cartItem }.flatten()
-    val systemUiController = rememberSystemUiController()
-    var isOpenDialog by remember { mutableStateOf(false) }
 
+    var dialogData by remember { mutableStateOf<DialogData?>(null) }
+
+    val systemUiController = rememberSystemUiController()
     SideEffect {
         systemUiController.setNavigationBarColor(color = Green500)
     }
@@ -97,7 +98,7 @@ fun CartScreen(navController: NavHostController) {
                             cartItem = item,
                             moveToDetail = { id -> navController.navigate("${MainScreen.WishItemDetail.route}/$id") },
                             onChangeItemCount = { count -> /*TODO*/ },
-                            onClickDelete = { id -> isOpenDialog = true },
+                            onClickDelete = { dialogData = DialogData.CartDelete() },
                         )
                         if (idx < cartItems.lastIndex) WishBoardDivider()
                     }
@@ -107,15 +108,9 @@ fun CartScreen(navController: NavHostController) {
         }
 
         WishBoardDialog(
-            isOpen = isOpenDialog,
-            textRes = WishBoardDialogTextRes(
-                titleRes = R.string.dialog_cart_title,
-                descriptionRes = R.string.dialog_cart_description,
-                dismissBtnTextRes = R.string.cancel,
-                confirmBtnTextRes = R.string.delete,
-            ),
+            dialogData = dialogData,
             onClickConfirm = {},
-            onDismissRequest = { isOpenDialog = false },
+            onDismissRequest = { dialogData = null },
         )
     }
 }
@@ -125,7 +120,7 @@ fun CartItem(
     cartItem: CartItem,
     moveToDetail: (Long) -> Unit = {},
     onChangeItemCount: (Int) -> Unit = {},
-    onClickDelete: (Long) -> Unit = {},
+    onClickDelete: () -> Unit = {},
 ) {
     val imageSize = 84
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -155,7 +150,7 @@ fun CartItem(
                     WishBoardIconButton(
                         modifier = Modifier.background(WishBoardTheme.colors.white),
                         iconRes = R.drawable.ic_delete_small_gray,
-                        onClick = { onClickDelete(cartItem.id) },
+                        onClick = { onClickDelete() },
                     )
                 }
             }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/DialogData.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/DialogData.kt
@@ -1,0 +1,66 @@
+package com.hyeeyoung.wishboard.presentation.dialog
+
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
+import java.io.Serializable
+
+sealed class DialogData(val dialogTextRes: WishBoardDialogTextRes, val isWarningDialog: Boolean = true) : Serializable {
+    data class WishItemDelete(
+        val itemId: Long? = null,
+    ) : DialogData(
+        dialogTextRes = WishBoardDialogTextRes(
+            titleRes = R.string.dialog_item_delete_title,
+            descriptionRes = R.string.dialog_item_delete_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.delete,
+        ),
+    )
+
+    data class FolderDelete(
+        val folderId: Long? = null,
+    ) : DialogData(
+        dialogTextRes = WishBoardDialogTextRes(
+            titleRes = R.string.dialog_folder_delete_title,
+            descriptionRes = R.string.dialog_folder_delete_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.delete,
+        ),
+    )
+
+    data class CartDelete(val itemId: Long? = null) : DialogData(
+        dialogTextRes = WishBoardDialogTextRes(
+            titleRes = R.string.dialog_cart_title,
+            descriptionRes = R.string.dialog_cart_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.delete,
+        ),
+    )
+
+    object Intro : DialogData(
+        dialogTextRes = WishBoardDialogTextRes(
+            titleRes = R.string.dialog_update_title,
+            descriptionRes = R.string.dialog_update_description,
+            dismissBtnTextRes = R.string.later,
+            confirmBtnTextRes = R.string.dialog_update_confirm_btn_text,
+        ),
+        isWarningDialog = false,
+    )
+
+    object Logout : DialogData(
+        dialogTextRes = WishBoardDialogTextRes(
+            titleRes = R.string.my_menu_logout,
+            descriptionRes = R.string.dialog_logout_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.my_menu_logout,
+        ),
+    )
+
+    object Withdraw : DialogData(
+        dialogTextRes = WishBoardDialogTextRes(
+            titleRes = R.string.dialog_withdraw_title,
+            descriptionRes = R.string.dialog_withdraw_description,
+            dismissBtnTextRes = R.string.cancel,
+            confirmBtnTextRes = R.string.dialog_withdraw_confirm_btn_text,
+        ),
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/ModalActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/ModalActivity.kt
@@ -1,0 +1,115 @@
+package com.hyeeyoung.wishboard.presentation.dialog
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.hyeeyoung.wishboard.presentation.folder.FolderListModalContent
+import com.hyeeyoung.wishboard.presentation.folder.FolderUploadModalContent
+import com.hyeeyoung.wishboard.presentation.noti.NotiModalContent
+import com.hyeeyoung.wishboard.presentation.upload.component.ShopLinkModalContent
+import com.hyeeyoung.wishboard.presentation.util.extension.getSerializable
+
+class ModalActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val modalData = intent.getSerializable(ARG_MODAL_DATA, ModalData::class.java)
+
+        setContent {
+            val systemUiController = rememberSystemUiController()
+            SideEffect {
+                when (modalData) {
+                    is ModalData.Modal -> systemUiController.setNavigationBarColor(Color.White)
+                    is ModalData.OptionModal -> systemUiController.setNavigationBarColor(Color.Transparent)
+                    else -> {}
+                }
+            }
+
+            when (modalData) {
+                is ModalData.Modal -> {
+                    WishBoardModal(
+                        titleRes = modalData.title,
+                        onDismissRequest = { this.finish() },
+                        content = { ModalContent(modalData = modalData) },
+                    )
+                }
+
+                is ModalData.OptionModal -> {
+                    WishBoardTwoOptionModal(
+                        topOption = modalData.topOption,
+                        bottomOption = modalData.bottomOption,
+                        isWarningBottom = modalData.isWarningBottomOption,
+                        onClickTop = { moveToPrevious(modalData) },
+                        onClickBottom = { moveToPrevious(modalData, false) },
+                        onDismissRequest = { finish() },
+                    )
+                }
+
+                else -> {}
+            }
+        }
+    }
+
+    @Composable
+    fun ModalContent(modalData: ModalData.Modal) {
+        when (modalData) {
+            is ModalData.Modal.FolderList -> FolderListModalContent(
+                selectedFolderId = modalData.selectedFolderId,
+                onClickFolder = { folder -> moveToPrevious(modalData.copy(selectedFolderId = folder.id, folder.name)) },
+            )
+
+            is ModalData.Modal.Noti -> NotiModalContent(
+                type = modalData.notiType,
+                date = modalData.notiDate,
+                onClickComplete = {},
+            )
+
+            is ModalData.Modal.NewFolder -> FolderUploadModalContent(onClickComplete = { name ->
+                moveToPrevious(modalData.copy(folderName = name))
+            })
+
+            is ModalData.Modal.FolderNameEdit -> FolderUploadModalContent(
+                folder = Pair(
+                    modalData.folderId,
+                    modalData.folderName,
+                ),
+                onClickComplete = { name -> moveToPrevious(modalData.copy(folderName = name)) },
+            )
+
+            is ModalData.Modal.ShopLink -> ShopLinkModalContent(
+                link = modalData.link,
+                onClickComplete = { link -> moveToPrevious(modalData.copy(link = link)) },
+            )
+        }
+    }
+
+    /** 옵션 모달 전용 이전 화면으로 돌아가기 + 데이터 전달 */
+    private fun moveToPrevious(modal: ModalData.OptionModal, isTop: Boolean = true) {
+        Intent().apply {
+            putExtra(ARG_MODAL_DATA, modal)
+            putExtra(ARG_TOP_OPTION, isTop)
+        }.also {
+            setResult(RESULT_OK, it)
+            finish()
+        }
+    }
+
+    private fun moveToPrevious(modal: ModalData.Modal) {
+        Intent().apply {
+            putExtra(ARG_MODAL_DATA, modal)
+        }.also {
+            setResult(RESULT_OK, it)
+            finish()
+        }
+    }
+
+    companion object {
+        const val ARG_MODAL_DATA = "modalData"
+        const val ARG_TOP_OPTION = "isTopOption"
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/ModalData.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/ModalData.kt
@@ -1,0 +1,64 @@
+package com.hyeeyoung.wishboard.presentation.dialog
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.result.ActivityResult
+import androidx.annotation.StringRes
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.presentation.util.type.NotiType
+import kotlinx.datetime.LocalDateTime
+import java.io.Serializable
+
+sealed class ModalData : Serializable {
+    sealed class Modal(@StringRes val title: Int) : ModalData() {
+        data class Noti(
+            val notiType: NotiType? = null,
+            val notiDate: LocalDateTime? = null,
+        ) : Modal(title = R.string.modal_noti_setting_title)
+
+        data class FolderList(val selectedFolderId: Long?, val selectedFolderName: String? = null) : Modal(
+            title = R.string.modal_folder_selection_title,
+        )
+
+        data class NewFolder(val folderName: String = "") : Modal(title = R.string.modal_new_folder_title) /*TODO*/
+
+        data class FolderNameEdit(
+            val folderId: Long,
+            val folderName: String,
+        ) : Modal(title = R.string.modal_folder_name_edit_title)
+
+        data class ShopLink(
+            val link: String,
+        ) : Modal(title = R.string.modal_shop_link_title)
+    }
+
+    sealed class OptionModal(
+        @StringRes val topOption: Int,
+        @StringRes val bottomOption: Int,
+        val isWarningBottomOption: Boolean = true,
+    ) : ModalData() {
+        data class FolderMore(
+            val folderId: Long,
+            val folderName: String,
+        ) : OptionModal(
+            topOption = R.string.modal_folder_name_edit_title,
+            bottomOption = R.string.dialog_folder_delete_title,
+        )
+
+        object ImageSelection : OptionModal(
+            topOption = R.string.modal_image_upload_camera,
+            bottomOption = R.string.modal_image_upload_gallery,
+            isWarningBottomOption = false,
+        )
+    }
+
+    fun openModal(context: Context, resultLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>) {
+        val intent = Intent(
+            context,
+            ModalActivity::class.java,
+        ).apply { putExtra(ModalActivity.ARG_MODAL_DATA, this@ModalData) }
+
+        resultLauncher.launch(intent)
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/WishBoardModal.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/WishBoardModal.kt
@@ -1,20 +1,18 @@
-package com.hyeeyoung.wishboard.designsystem.component.dialog
+package com.hyeeyoung.wishboard.presentation.dialog
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -23,32 +21,30 @@ import androidx.compose.ui.unit.dp
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
-import com.hyeeyoung.wishboard.presentation.noti.NotiModalContent
-import kotlinx.coroutines.launch
+import com.hyeeyoung.wishboard.presentation.folder.FolderUploadModalContent
+import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WishBoardModal(
-    isOpen: Boolean,
-    @StringRes titleRes: Int,
-    onDismissRequest: () -> Unit,
-    content: @Composable () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState()
-    val scope = rememberCoroutineScope()
-
-    if (!isOpen) return
-    ModalBottomSheet(
-        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
-        onDismissRequest = { onDismissRequest() },
-        sheetState = sheetState,
-        containerColor = WishBoardTheme.colors.white,
-        dragHandle = null,
+fun WishBoardModal(@StringRes titleRes: Int, onDismissRequest: () -> Unit = {}, content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
     ) {
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .noRippleClickable { onDismissRequest() },
+        )
         Box(
             modifier = Modifier
                 .heightIn(max = 317.dp)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .background(
+                    color = WishBoardTheme.colors.white,
+                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+                ),
+            contentAlignment = Alignment.TopCenter,
         ) {
             Surface(
                 modifier = Modifier
@@ -58,13 +54,7 @@ fun WishBoardModal(
                 WishBoardIconButton(
                     modifier = Modifier.background(WishBoardTheme.colors.white),
                     iconRes = R.drawable.ic_close,
-                    onClick = {
-                        scope.launch { sheetState.hide() }.invokeOnCompletion {
-                            if (!sheetState.isVisible) {
-                                onDismissRequest()
-                            }
-                        }
-                    },
+                    onClick = { onDismissRequest() },
                 )
             }
 
@@ -85,11 +75,8 @@ fun WishBoardModal(
 
 @Preview
 @Composable
-fun PreviewWishBoardModal() {
-    WishBoardModal(
-        isOpen = true,
-        titleRes = R.string.wish_item_link_sharing_upload_noti_setting,
-        onDismissRequest = {},
-        content = { NotiModalContent(onClickComplete = {}) },
-    )
+fun PreviewFolderUploadModal() {
+    WishBoardModal(titleRes = R.string.modal_new_folder_title) {
+        FolderUploadModalContent(onClickComplete = {})
+    }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/WishBoardTwoOptionModal.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/dialog/WishBoardTwoOptionModal.kt
@@ -1,0 +1,107 @@
+package com.hyeeyoung.wishboard.presentation.dialog
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
+import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
+import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
+
+@Composable
+fun WishBoardTwoOptionModal(
+    @StringRes topOption: Int,
+    @StringRes bottomOption: Int,
+    isWarningBottom: Boolean = true,
+    onClickTop: () -> Unit = {},
+    onClickBottom: () -> Unit = {},
+    onDismissRequest: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+    ) {
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .noRippleClickable { onDismissRequest() },
+        )
+        Column(
+            modifier = Modifier
+                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+        ) {
+            Column(
+                modifier = Modifier.background(
+                    color = WishBoardTheme.colors.white,
+                    shape = RoundedCornerShape(16.dp),
+                ),
+            ) {
+                Text(
+                    modifier = Modifier
+                        .noRippleClickable {
+                            onClickTop()
+                        }
+                        .padding(vertical = 16.dp)
+                        .fillMaxWidth(),
+                    text = stringResource(topOption),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = WishBoardTheme.colors.gray600,
+                    textAlign = TextAlign.Center,
+                )
+                WishBoardDivider()
+                Text(
+                    modifier = Modifier
+                        .noRippleClickable {
+                            onClickBottom()
+                        }
+                        .padding(vertical = 16.dp)
+                        .fillMaxWidth(),
+                    text = stringResource(bottomOption),
+                    style = WishBoardTheme.typography.suitB3,
+                    color = if (isWarningBottom) WishBoardTheme.colors.pink700 else WishBoardTheme.colors.gray600,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(modifier = Modifier.size(4.dp))
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .noRippleClickable {
+                        onDismissRequest()
+                    }
+                    .background(color = WishBoardTheme.colors.white, shape = RoundedCornerShape(16.dp))
+                    .padding(vertical = 16.dp),
+                text = stringResource(R.string.cancel),
+                style = WishBoardTheme.typography.suitB3,
+                color = WishBoardTheme.colors.gray600,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewWishBoardTwoOptionModal() {
+    WishBoardTwoOptionModal(
+        topOption = R.string.modal_folder_name_edit_title,
+        bottomOption = R.string.dialog_folder_delete_title,
+        onDismissRequest = {},
+    )
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderListModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderListModalContent.kt
@@ -29,18 +29,18 @@ import com.hyeeyoung.wishboard.designsystem.component.WishBoardEmptyView
 import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardDivider
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.presentation.model.Folder
+import com.hyeeyoung.wishboard.presentation.upload.model.SelectedFolder
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
 
 @Composable
-fun FolderListModalContent(selectedFolderId: Long?) {
+fun FolderListModalContent(selectedFolderId: Long?, onClickFolder: (SelectedFolder) -> Unit) {
     val folder = Folder(
         id = 1L,
         name = "아우터",
         thumbnail = "https://url.kr/8vwf1e",
         itemCount = 1,
     )
-//    val folders = List(8) { folder.copy(id = it.toLong()) } // TODO 서버 연동 후 삭제
-    val folders = emptyList<Folder>()
+    val folders = List(8) { folder.copy(id = it.toLong()) } // TODO 서버 연동 후 삭제
     var selectedId by remember { mutableStateOf(selectedFolderId) }
 
     if (folders.isEmpty()) {
@@ -61,7 +61,10 @@ fun FolderListModalContent(selectedFolderId: Long?) {
                 HorizontalFolderItem(
                     folder = folder,
                     isSelected = selectedId == folder.id,
-                    onClickFolder = { folderId -> selectedId = folderId },
+                    onClickFolder = { selectedFolder ->
+                        selectedId = selectedFolder.id
+                        onClickFolder(selectedFolder)
+                    },
                 )
                 if (idx != folders.lastIndex) {
                     WishBoardDivider()
@@ -72,11 +75,11 @@ fun FolderListModalContent(selectedFolderId: Long?) {
 }
 
 @Composable
-fun HorizontalFolderItem(folder: Folder, isSelected: Boolean, onClickFolder: (Long) -> Unit) {
+fun HorizontalFolderItem(folder: Folder, isSelected: Boolean, onClickFolder: (SelectedFolder) -> Unit) {
     Row(
         modifier = Modifier
             .padding(horizontal = 16.dp, vertical = 8.dp)
-            .noRippleClickable { onClickFolder(folder.id) },
+            .noRippleClickable { onClickFolder(SelectedFolder(folder.id, folder.name)) },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ColoredImage(
@@ -111,5 +114,5 @@ fun HorizontalFolderItem(folder: Folder, isSelected: Boolean, onClickFolder: (Lo
 @Composable
 @Preview
 fun PreviewFolderListModalContent() {
-    FolderListModalContent(1L)
+    FolderListModalContent(1L, onClickFolder = {})
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderUploadModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderUploadModalContent.kt
@@ -16,10 +16,10 @@ import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
 import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
 
 @Composable
-fun FolderUploadModalContent(folder: Pair<Long, String>? = null) {
+fun FolderUploadModalContent(folder: Pair<Long, String>? = null, onClickComplete: (String) -> Unit) {
     val nameInput = remember { mutableStateOf(folder?.second ?: "") }
 
-    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp)) {
+    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
         Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
             WishBoardTextField(
                 input = nameInput,
@@ -30,7 +30,7 @@ fun FolderUploadModalContent(folder: Pair<Long, String>? = null) {
 
         WishBoardWideButton(
             enabled = true,
-            onClick = { /*TODO*/ },
+            onClick = { onClickComplete(nameInput.value) },
             text = stringResource(id = if (folder == null) R.string.add else R.string.modal_folder_name_edit_btn_text),
         )
     }
@@ -39,11 +39,11 @@ fun FolderUploadModalContent(folder: Pair<Long, String>? = null) {
 @Composable
 @Preview
 fun PreviewNewFolderModalContent() {
-    FolderUploadModalContent()
+    FolderUploadModalContent(onClickComplete = {})
 }
 
 @Composable
 @Preview
 fun PreviewFolderEditModalContent() {
-    FolderUploadModalContent(Pair(1L, "셀린느"))
+    FolderUploadModalContent(Pair(1L, "셀린느"), onClickComplete = {})
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/intro/IntroScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/intro/IntroScreen.kt
@@ -33,19 +33,19 @@ import com.hyeeyoung.wishboard.config.navigation.screen.SignScreen
 import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardDialog
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
-import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
+import com.hyeeyoung.wishboard.presentation.dialog.DialogData
 import kotlinx.coroutines.delay
 
 @Composable
 fun IntroScreen(navController: NavHostController) {
     val context = LocalContext.current
-    var isOpenDialog by remember { mutableStateOf(false) }
+    var dialogData by remember { mutableStateOf<DialogData?>(null) }
 
     LaunchedEffect(Unit) {
         delay(2000L)
         checkForNewVersionUpdate(
             context = context,
-            updateDialogState = { isOpenDialog = true },
+            showDialog = { dialogData = DialogData.Intro },
             moveToNext = { navigateToNext(navController) },
         )
     }
@@ -63,21 +63,14 @@ fun IntroScreen(navController: NavHostController) {
         }
 
         WishBoardDialog(
-            isOpen = isOpenDialog,
-            textRes = WishBoardDialogTextRes(
-                titleRes = R.string.dialog_update_title,
-                descriptionRes = R.string.dialog_update_description,
-                dismissBtnTextRes = R.string.later,
-                confirmBtnTextRes = R.string.dialog_update_confirm_btn_text,
-            ),
-            isWarningDialog = false,
+            dialogData = dialogData,
             onClickConfirm = {},
-            onDismissRequest = { isOpenDialog = false },
+            onDismissRequest = { dialogData = null },
         )
     }
 }
 
-private fun checkForNewVersionUpdate(context: Context, updateDialogState: () -> Unit, moveToNext: () -> Unit) {
+private fun checkForNewVersionUpdate(context: Context, showDialog: () -> Unit, moveToNext: () -> Unit) {
     val appUpdateManager = AppUpdateManagerFactory.create(context)
     val appUpdateInfoTask = appUpdateManager.appUpdateInfo
 
@@ -86,7 +79,7 @@ private fun checkForNewVersionUpdate(context: Context, updateDialogState: () -> 
             appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE) &&
             appUpdateInfo.availableVersionCode() != BuildConfig.VERSION_CODE
         ) {
-            updateDialogState()
+            showDialog()
         } else {
             moveToNext()
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -40,7 +41,7 @@ import com.hyeeyoung.wishboard.designsystem.component.divider.WishBoardThickDivi
 import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
 import com.hyeeyoung.wishboard.designsystem.component.topbar.WishBoardMainTopBar
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
-import com.hyeeyoung.wishboard.presentation.model.WishBoardDialogTextRes
+import com.hyeeyoung.wishboard.presentation.dialog.DialogData
 import com.hyeeyoung.wishboard.presentation.util.constant.WishBoardUrl
 import com.hyeeyoung.wishboard.presentation.util.extension.moveToWebView
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
@@ -51,7 +52,7 @@ fun MyScreen(navController: NavHostController) {
     // TODO 클릭 이벤트 핸들링
 
     val context = LocalContext.current
-    var dialogType by remember { mutableStateOf<DialogType?>(null) }
+    var dialogData by remember { mutableStateOf<DialogData?>(null) }
 
     val myMenuComponents =
         listOf(
@@ -110,11 +111,11 @@ fun MyScreen(navController: NavHostController) {
             MyMenuComponent.Divider,
             MyMenuComponent.Menu(
                 nameRes = R.string.my_menu_logout,
-                onClickMenu = { dialogType = DialogType.LOGOUT },
+                onClickMenu = { dialogData = DialogData.Logout },
             ),
             MyMenuComponent.Menu(
                 nameRes = R.string.my_menu_withdraw,
-                onClickMenu = { dialogType = DialogType.WITHDRAW },
+                onClickMenu = { dialogData = DialogData.Withdraw },
             ),
         )
 
@@ -136,33 +137,16 @@ fun MyScreen(navController: NavHostController) {
             item { Spacer(modifier = Modifier.size(64.dp)) }
         }
 
-        val emailInput = remember { mutableStateOf("") }
-
-        dialogType?.let { type ->
-            WishBoardDialog(
-                isOpen = true,
-                textRes = type.dialogTextRes,
-                isWarningDialog = type.isWaringDialog,
-                onClickConfirm = {},
-                onDismissRequest = { dialogType = null },
-                content =
-                if (type == DialogType.WITHDRAW) {
-                    {
-                        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 14.dp)) {
-                            WishBoardTextField(
-                                input = emailInput,
-                                placeholder = stringResource(id = R.string.sign_email_placeholder),
-                                errorMsg = stringResource(
-                                    id = R.string.dialog_withdraw_email_error,
-                                ),
-                            )
-                        }
-                    }
-                } else {
-                    null
-                },
-            )
-        }
+        WishBoardDialog(
+            dialogData = dialogData,
+            onClickConfirm = {},
+            onDismissRequest = { dialogData = null },
+            content = if (dialogData is DialogData.Withdraw) {
+                { WithdrawDialogContent() }
+            } else {
+                null
+            },
+        )
     }
 }
 
@@ -203,6 +187,24 @@ fun Profile(onClickProfileEdit: () -> Unit) {
     }
 }
 
+@Composable
+fun WithdrawDialogContent() {
+    val emailInput = remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 14.dp)
+            .height(60.dp),
+    ) {
+        WishBoardTextField(
+            input = emailInput,
+            placeholder = stringResource(id = R.string.sign_email_placeholder),
+            errorMsg = stringResource(
+                id = R.string.dialog_withdraw_email_error,
+            ),
+        )
+    }
+}
+
 sealed class MyMenuComponent {
     data class Menu(
         @StringRes val nameRes: Int,
@@ -230,27 +232,6 @@ fun MenuItem(menu: MyMenuComponent.Menu) {
         )
         menu.endComponent?.let { endComponent -> endComponent() }
     }
-}
-
-enum class DialogType(val dialogTextRes: WishBoardDialogTextRes, val isWaringDialog: Boolean) {
-    LOGOUT(
-        WishBoardDialogTextRes(
-            titleRes = R.string.my_menu_logout,
-            descriptionRes = R.string.dialog_logout_description,
-            dismissBtnTextRes = R.string.cancel,
-            confirmBtnTextRes = R.string.my_menu_logout,
-        ),
-        true,
-    ),
-    WITHDRAW(
-        WishBoardDialogTextRes(
-            titleRes = R.string.dialog_withdraw_title,
-            descriptionRes = R.string.dialog_withdraw_description,
-            dismissBtnTextRes = R.string.cancel,
-            confirmBtnTextRes = R.string.dialog_withdraw_confirm_btn_text,
-        ),
-        true,
-    ),
 }
 
 @Composable

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/NotiModalContent.kt
@@ -29,13 +29,13 @@ import kotlinx.datetime.LocalDateTime
 private val notiType = NotiType.values().map { it.str }
 
 @Composable
-fun NotiModalContent(type: NotiType? = null, date: LocalDateTime? = null) {
+fun NotiModalContent(type: NotiType? = null, date: LocalDateTime? = null, onClickComplete: () -> Unit) {
     val selectedType = remember { mutableStateOf("") }
     val selectedDate = remember { mutableStateOf("") }
     val selectedHour = remember { mutableStateOf("") }
     val selectedMinute = remember { mutableStateOf("") }
 
-    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp)) {
+    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
         Box(modifier = Modifier.weight(1f)) {
             Canvas(
                 modifier = Modifier
@@ -91,12 +91,14 @@ fun NotiModalContent(type: NotiType? = null, date: LocalDateTime? = null) {
             style = WishBoardTheme.typography.suitD3,
             color = WishBoardTheme.colors.gray300,
         )
-        WishBoardWideButton(enabled = true, onClick = { /*TODO*/ }, text = stringResource(id = R.string.complete))
+        WishBoardWideButton(enabled = true, onClick = {
+            onClickComplete()
+        }, text = stringResource(id = R.string.complete))
     }
 }
 
 @Composable
 @Preview(showSystemUi = true)
 fun PreviewNotiModalContent() {
-    NotiModalContent()
+    NotiModalContent(onClickComplete = {})
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/LinkSharingWishUploadActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/LinkSharingWishUploadActivity.kt
@@ -4,6 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 class LinkSharingWishUploadActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -18,6 +21,11 @@ class LinkSharingWishUploadActivity : ComponentActivity() {
         }
 
         setContent {
+            val systemUiController = rememberSystemUiController()
+            SideEffect {
+                systemUiController.setNavigationBarColor(Color.White)
+            }
+
             if (url.isEmpty()) return@setContent
             LinkSharingWishUploadScreen(url = url, onClickClose = { finish() })
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/LinkSharingWishUploadScreen.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/LinkSharingWishUploadScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -41,17 +42,14 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.designsystem.component.ColoredImage
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardIconButton
 import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
-import com.hyeeyoung.wishboard.designsystem.component.dialog.WishBoardModal
 import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardMiniSingleTextField
 import com.hyeeyoung.wishboard.designsystem.style.MontserratFamily
 import com.hyeeyoung.wishboard.designsystem.style.WishBoardTheme
 import com.hyeeyoung.wishboard.designsystem.style.WishboardTheme
 import com.hyeeyoung.wishboard.designsystem.util.PriceTransformation
-import com.hyeeyoung.wishboard.presentation.folder.FolderUploadModalContent
+import com.hyeeyoung.wishboard.presentation.dialog.ModalData
 import com.hyeeyoung.wishboard.presentation.model.FolderSummary
-import com.hyeeyoung.wishboard.presentation.noti.NotiModalContent
-import com.hyeeyoung.wishboard.presentation.upload.model.ModalInfo
-import com.hyeeyoung.wishboard.presentation.upload.model.ModalRoute
+import com.hyeeyoung.wishboard.presentation.util.extension.rememberModalLauncher
 import com.hyeeyoung.wishboard.presentation.util.extension.isEmptyOrBlank
 import com.hyeeyoung.wishboard.presentation.util.extension.makeValidPriceStr
 import com.hyeeyoung.wishboard.presentation.util.extension.noRippleClickable
@@ -64,14 +62,27 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
     val priceInput = remember { mutableStateOf("") }
     val image = "https://url.kr/8vwf1e" // TODO 서버 연동 필요
 
-    var modalInfo by remember { mutableStateOf(ModalInfo(false)) }
+    val context = LocalContext.current
+    val modalLauncher = rememberModalLauncher { _, data ->
+        when (data) {
+            is ModalData.Modal.Noti -> {}
+
+            is ModalData.Modal.NewFolder -> {}
+
+            else -> {}
+        }
+    }
 
     WishboardTheme {
         Column(
-            modifier = Modifier
-                .fillMaxSize(),
-            verticalArrangement = Arrangement.Bottom,
+            modifier = Modifier.fillMaxSize(),
         ) {
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .noRippleClickable { onClickClose() },
+            )
             Box(contentAlignment = Alignment.TopCenter) {
                 Column(
                     modifier = Modifier
@@ -90,6 +101,7 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
                             .padding(top = 5.dp, end = 8.dp),
                     ) {
                         WishBoardIconButton(
+                            modifier = Modifier.background(WishBoardTheme.colors.white),
                             iconRes = R.drawable.ic_close,
                             onClick = { onClickClose() },
                         )
@@ -125,7 +137,11 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
 
                     Row(
                         modifier = Modifier
-                            .noRippleClickable { modalInfo = ModalInfo(true, ModalRoute.NOTI) }
+                            .noRippleClickable {
+                                ModalData.Modal
+                                    .Noti()
+                                    .openModal(context, modalLauncher)
+                            }
                             .padding(8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -171,7 +187,7 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
                         item {
-                            NewFolder(onClickNew = { modalInfo = ModalInfo(true, ModalRoute.FOLDER) })
+                            NewFolder(onClickNew = { ModalData.Modal.NewFolder().openModal(context, modalLauncher) })
                         }
                         items(folders) {
                             FolderItem(
@@ -220,17 +236,6 @@ fun LinkSharingWishUploadScreen(url: String, onClickClose: () -> Unit = {}) {
                         contentDescription = null,
                     )
                 }
-            }
-        }
-
-        WishBoardModal(
-            isOpen = modalInfo.isOpen,
-            titleRes = modalInfo.modalRoute?.titleRes ?: R.string.modal_folder_selection_title,
-            onDismissRequest = { modalInfo = ModalInfo(false) },
-        ) {
-            when (modalInfo.modalRoute) {
-                ModalRoute.FOLDER -> FolderUploadModalContent()
-                else -> NotiModalContent()
             }
         }
     }
@@ -308,7 +313,7 @@ fun NewFolder(onClickNew: () -> Unit) {
     }
 }
 
-@Preview
+@Preview(showSystemUi = true)
 @Composable
 fun PreviewLinkSharingWishUploadScreen() {
     LinkSharingWishUploadScreen(url = "")

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/component/ShopLinkModalContent.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/component/ShopLinkModalContent.kt
@@ -16,9 +16,9 @@ import com.hyeeyoung.wishboard.designsystem.component.button.WishBoardWideButton
 import com.hyeeyoung.wishboard.designsystem.component.textfield.WishBoardTextField
 
 @Composable
-fun ShopLinkModalContent(link: String? = null, onClickBtn: () -> Unit = {}) {
+fun ShopLinkModalContent(link: String? = null, onClickComplete: (String) -> Unit) {
     val linkInput = remember { mutableStateOf(link ?: "") }
-    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp)) {
+    Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
         Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
             WishBoardTextField(
                 input = linkInput,
@@ -29,7 +29,7 @@ fun ShopLinkModalContent(link: String? = null, onClickBtn: () -> Unit = {}) {
 
         WishBoardWideButton(
             enabled = true,
-            onClick = { onClickBtn() },
+            onClick = { onClickComplete(linkInput.value) },
             text = stringResource(id = R.string.modal_shop_link_item_load_btn_text),
         )
     }
@@ -38,5 +38,5 @@ fun ShopLinkModalContent(link: String? = null, onClickBtn: () -> Unit = {}) {
 @Composable
 @Preview
 fun PreviewShopLinkModalContent() {
-    ShopLinkModalContent()
+    ShopLinkModalContent(onClickComplete = {})
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/model/SelectedFolder.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/upload/model/SelectedFolder.kt
@@ -1,0 +1,6 @@
+package com.hyeeyoung.wishboard.presentation.upload.model
+
+data class SelectedFolder(
+    val id: Long? = null,
+    val name: String? = null,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/extension/IntentExt.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/util/extension/IntentExt.kt
@@ -1,0 +1,28 @@
+package com.hyeeyoung.wishboard.presentation.util.extension
+
+import android.content.Intent
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import com.hyeeyoung.wishboard.presentation.dialog.ModalActivity
+import com.hyeeyoung.wishboard.presentation.dialog.ModalData
+import java.io.Serializable
+
+fun <T : Serializable> Intent.getSerializable(name: String, clazz: Class<T>): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializableExtra(name, clazz)
+    } else {
+        getSerializableExtra(name) as? T ?: throw NullPointerException("타입 변환 실패")
+    }
+}
+
+@Composable
+fun rememberModalLauncher(afterModalDataInput: (Boolean, ModalData?) -> Unit) =
+    rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) {
+        it.data?.let { intent ->
+            val isTopOption = intent.getBooleanExtra(ModalActivity.ARG_TOP_OPTION, false)
+            val data = intent.getSerializable(ModalActivity.ARG_MODAL_DATA, ModalData::class.java)
+            afterModalDataInput(isTopOption, data)
+        }
+    }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,11 +3,11 @@
 
     <style name="Theme.Wishboard" parent="android:Theme.Material.Light.NoActionBar" />
 
-    <style name="Theme.WishLinkSharing" parent="Theme.Wishboard">
+    <style name="Theme.Modal" parent="Theme.Wishboard">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/white</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:backgroundDimEnabled">true</item>
     </style>
+
 </resources>


### PR DESCRIPTION
## What is this PR? 🔍
- closed #48

## Key Changes 🔑
1. ModalBottomSheet -> Activity화
   - Activity화 이유 : ModalBottomSheet를 사용하면 content에 텍스트필드를 포함할 경우, 키보드가 올라오면서 모달의 하단 일부가 가려지는 버그가 있음. 현재 사용 중인 라이브러리 버전에서 ModalBottomSheet는 실험용으로 제공되고 있고, 이와 같은 일부 버그가 발견되어 stable이 될 때까지 Activity를 사용할 예정
   - 추가로 기본 제공 다이얼로그의 배경 컬러와 거의 비슷해짐. ModalBottomSheet의 배경 컬러는 기존 다이얼로그 배경보다 눈에 띄게 명도가 높았음

2. Dialog 관련 코드 리팩토링
  - 모달과 비슷한 로직으로 다이얼로그를 show, dismiss함 -> 모달 로직과 통일되면서 보일러플레이트 코드 제거됨.

|ModalBottomSheet|Activity|
|---|---|
|<img width="300" alt="스크린샷 2023-09-15 오후 7 05 51" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/62cc5085-cf87-4b73-9c97-7395f0d9a725">|<img width="300" alt="image" src="https://github.com/hyeeyoung/wishboard-android-compose/assets/48701368/0b146f6c-0459-40ba-b4a5-8df9bda81005">|
