### PR TITLE
캘린더에서 상세뷰 이동 후 복귀했을 때 상태값이 초기화되는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/CalendarViewModel.kt
@@ -1,0 +1,34 @@
+package com.hyeeyoung.wishboard.presentation.calendar
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.time.LocalDate
+
+class CalendarViewModel : ViewModel() {
+    private val _selectedDate = MutableStateFlow(LocalDate.now())
+    val selectedDate get() = _selectedDate.asStateFlow()
+
+    private val latestCalendarPage = MutableStateFlow(INITIAL_PAGE)
+
+    fun changeCalendarPage(currentPate: Int) {
+        val diff = currentPate - latestCalendarPage.value
+
+        if (diff < 0) {
+            _selectedDate.value = _selectedDate.value.minusMonths(1)
+        } else if (diff > 0) {
+            _selectedDate.value = _selectedDate.value.plusMonths(1)
+        }
+
+        latestCalendarPage.value = currentPate
+    }
+
+    fun updateSelectedDate(date: LocalDate) {
+        _selectedDate.value = date
+    }
+
+    companion object {
+        const val PAGE_COUNT = Int.MAX_VALUE
+        const val INITIAL_PAGE = PAGE_COUNT / 2
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/component/CalendarTable.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/calendar/component/CalendarTable.kt
@@ -43,7 +43,7 @@ fun CalendarTable(
         }
     }
 
-    Column() {
+    Column {
         WishBoardDivider()
         HorizontalPager(pageCount = pageCount, state = pagerState) {
             DateTable(selectedDate, onSelect, notiDateList)
@@ -67,9 +67,9 @@ fun DateTable(
     val cellSize = screenWidth / COL_SIZE
     val dateCellModifier = Modifier.size(cellSize)
 
-    Column() {
+    Column {
         repeat(rowSize) { r ->
-            Row() {
+            Row {
                 repeat(COL_SIZE) { c ->
                     if (day > lastDay) return
                     val dateOrNull =
@@ -156,7 +156,7 @@ fun CalendarTablePreview() {
         onSelect = {},
         notiDateList = listOf(LocalDate.of(2023, 7, 3), LocalDate.of(2023, 7, 20)),
         pagerState = rememberPagerState(),
-        pageCount = 1,
+        pageCount = 24,
         onChangePage = {},
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ androidx-test-espresso = "3.5.1"
 junit = "4.13.2"
 
 compose-compiler = "1.4.4"
-compose-bom = "2023.05.01"
+compose-bom = "2023.01.00"
 material = "1.1.1"
 compose-navigation = "2.5.3"
 compose-constraintlayout = "1.0.1"


### PR DESCRIPTION
## What is this PR? 🔍
- closed #56

## Key Changes 🔑
1. 캘린더에서 상세뷰 이동 후 복귀했을 때 복귀 전의 캘린더 날짜가 아닌 항상 오늘 날짜를 가리키는 버그 수정
   - 원인 : 복귀하면서 다시 CalendarScreen 컴포저블이 재호출되면서 날짜 상태값이 초기값(오늘 날짜)으로 돌아감
   - 해결 : 뷰모델 사용 
